### PR TITLE
add a cache for mapping uris to paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ Sets the HLS segment duration in milliseconds.
 
 Sets the secret that is used to generate the TS encryption key, if empty, no encryption is performed.
 
+#### vod_moov_cache
+* **syntax**: `vod_moov_cache zone_name zone_size`
+* **default**: `off`
+* **context**: `http`, `server`, `location`
+
+Configures the size and shared memory object name of the moov atom cache
+
 #### vod_initial_read_size
 * **syntax**: `vod_initial_read_size size`
 * **default**: `4K`
@@ -99,7 +106,7 @@ Sets the size of the initial read operation of the MP4 file.
 
 #### vod_max_moov_size
 * **syntax**: `vod_max_moov_size size`
-* **default**: `1MB`
+* **default**: `32MB`
 * **context**: `http`, `server`, `location`
 
 Sets the maximum supported MP4 moov atom size.
@@ -152,6 +159,13 @@ Sets the timeout in milliseconds for sending data to the upstream (remote/mapped
 * **context**: `http`, `server`, `location`
 
 Sets the timeout in milliseconds for reading data from the upstream (remote/mapped modes only).
+
+#### vod_path_mapping_cache
+* **syntax**: `vod_path_mapping_cache zone_name zone_size`
+* **default**: `off`
+* **context**: `http`, `server`, `location`
+
+Configures the size and shared memory object name of the path mapping cache (mapped mode only).
 
 #### vod_path_response_prefix
 * **syntax**: `vod_path_response_prefix prefix`
@@ -271,10 +285,16 @@ The name of the encryption key file name (only relevant when vod_secret_key is u
 			location /content/ {
 				vod;
 				vod_mode local;
+				vod_moov_cache moov_cache 512m;
 				vod_fallback_upstream fallback;
 
 				root /web/content;
 				
+				open_file_cache          max=1000 inactive=5m;
+				open_file_cache_valid    2m;
+				open_file_cache_min_uses 1;
+				open_file_cache_errors   on;
+
 				gzip on;
 				gzip_types application/vnd.apple.mpegurl;
 
@@ -302,11 +322,18 @@ The name of the encryption key file name (only relevant when vod_secret_key is u
 			location ~ ^/p/\d+/(sp/\d+/)?serveFlavor/ {
 				vod;
 				vod_mode mapped;
+				vod_moov_cache moov_cache 512m;
 				vod_secret_key mukkaukk;
 				vod_upstream kalapi;
 				vod_upstream_host_header www.kaltura.com;
 				vod_upstream_extra_args "pathOnly=1";
+				vod_path_mapping_cache mapping_cache 5m;
 				vod_fallback_upstream fallback;
+
+				open_file_cache          max=1000 inactive=5m;
+				open_file_cache_valid    2m;
+				open_file_cache_min_uses 1;
+				open_file_cache_errors   on;
 
 				gzip on;
 				gzip_types application/vnd.apple.mpegurl;
@@ -330,6 +357,7 @@ The name of the encryption key file name (only relevant when vod_secret_key is u
 			location ~ ^/p/\d+/(sp/\d+/)?serveFlavor/ {
 				vod;
 				vod_mode remote;
+				vod_moov_cache moov_cache 512m;
 				vod_secret_key mukkaukk;
 				vod_upstream kalapi;
 				vod_upstream_host_header www.kaltura.com;

--- a/ngx_child_http_request.h
+++ b/ngx_child_http_request.h
@@ -10,16 +10,19 @@ typedef void (*child_request_callback_t)(void* context, ngx_int_t rc, ngx_buf_t*
 typedef struct {
 	child_request_callback_t callback;
 	void* callback_context;
+	ngx_event_t* complete_event;
+	ngx_int_t request_status;
 
 	ngx_buf_t* request_buffer;
+
+	u_char* headers_buffer;
+	size_t headers_buffer_size;
+	ngx_flag_t save_response_headers;
 
 	u_char* response_buffer;
 	off_t response_buffer_size;
 
-	u_char* headers_buffer;
-	size_t headers_buffer_size;
-
-	ngx_flag_t save_response_headers;
+	ngx_pool_cleanup_t *cleanup;
 } child_request_context_t;
 
 // request initiation function

--- a/ngx_http_vod_conf.h
+++ b/ngx_http_vod_conf.h
@@ -20,6 +20,7 @@ typedef struct ngx_http_vod_loc_conf_s {
 	ngx_http_upstream_conf_t   upstream;
 	ngx_str_t upstream_host_header;
 	ngx_str_t upstream_extra_args;
+	ngx_shm_zone_t* path_mapping_cache_zone;
 	ngx_str_t path_response_prefix;
 	ngx_str_t path_response_postfix;
 	size_t max_path_length;


### PR DESCRIPTION
also, call the child request callback using an event since the request may
be closed from within the callback
