### PR TITLE
few small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Sets the upstream that should be used for reading the MP4 file (remote mode) or 
 
 #### vod_upstream_host_header
 * **syntax**: `vod_upstream_host_header host_name`
-* **default**: `none`
+* **default**: `the host name of original request`
 * **context**: `http`, `server`, `location`
 
 Sets the value of the HTTP host header that should be sent to the upstream (remote/mapped modes only).

--- a/ngx_child_http_request.c
+++ b/ngx_child_http_request.c
@@ -370,10 +370,25 @@ init_request_buffer(
 	off_t range_end,
 	ngx_str_t* extra_headers)
 {
+	ngx_http_core_srv_conf_t  *cscf;
 	ngx_flag_t range_request = (range_start >= 0) && (range_end >= 0);
 	ngx_buf_t *b;
 	size_t len;
 	u_char* p;
+
+	// if the host name is empty, use by default the host name of the incoming request
+	if (host_name->len == 0)
+	{
+		if (r->headers_in.host != NULL)
+		{
+			host_name = &r->headers_in.host->value;
+		}
+		else
+		{
+			cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+			host_name = &cscf->server_name;
+		}
+	}
 
 	// calculate the request size
 	len =

--- a/ngx_http_vod_conf.c
+++ b/ngx_http_vod_conf.c
@@ -101,13 +101,6 @@ ngx_http_vod_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 				"\"vod_upstream\" is mandatory for remote/mapped modes");
 			return NGX_CONF_ERROR;
 		}
-
-		if (conf->upstream_host_header.len == 0)
-		{
-			ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-				"\"vod_upstream_host_header\" is mandatory for remote/mapped modes");
-			return NGX_CONF_ERROR;
-		}
 	}
 	else
 	{

--- a/test/compare_ts_segments.py
+++ b/test/compare_ts_segments.py
@@ -89,8 +89,8 @@ def compareFfprobeOutputs(file1, file2):
 def compareTsUris(uri1, uri2, segmentIndex):
 	print 'comparing %s %s' % (uri1, uri2)
 	commands = [
-		'curl -s %s%s > %s' % (URL1_PREFIX, uri1, TEMP_TS_FILE1),
-		'curl -s %s%s > %s' % (URL2_PREFIX, uri2, TEMP_TS_FILE2),
+		"""curl -s '%s%s' > %s""" % (URL1_PREFIX, uri1, TEMP_TS_FILE1),
+		"""curl -s '%s%s' > %s""" % (URL2_PREFIX, uri2, TEMP_TS_FILE2),
 	]
 	for command in commands:
 		os.system(command)

--- a/vod/muxer.c
+++ b/vod/muxer.c
@@ -2,7 +2,7 @@
 
 // from ffmpeg mpegtsenc
 #define DEFAULT_PES_HEADER_FREQ 16
-#define DEFAULT_PES_PAYLOAD_SIZE (((DEFAULT_PES_HEADER_FREQ - 1) * 184 + 170) * 2)			// x2 to match akamai
+#define DEFAULT_PES_PAYLOAD_SIZE (((DEFAULT_PES_HEADER_FREQ - 1) * 184 + 170) * 2)
 
 static int 
 compare_streams(const void *s1, const void *s2)


### PR DESCRIPTION
- if no vod_upstream_host_header was specified default to the host of the request
- add specific error for empty path mapping response
- include the host name in the request cache key, since serveFlavor may enforce specific hosts
