### PR TITLE
allow ts segments with zero frames

### DIFF
--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -121,6 +121,7 @@ extract_uri_tokens(ngx_http_request_t* r, request_params_t* request_params, u_ch
 static bool_t 
 parse_required_tracks(ngx_http_request_t* r, u_char* start_pos, u_char* end_pos, bool_t has_stream_index, request_params_t* request_params)
 {
+	ngx_int_t segment_index;
 	int stream_index;
 	int media_type;
 	u_char* next_pos;
@@ -142,13 +143,14 @@ parse_required_tracks(ngx_http_request_t* r, u_char* start_pos, u_char* end_pos,
 			// segment index
 			has_stream_index = FALSE;
 
-			request_params->segment_index = ngx_atoi(start_pos, next_pos - start_pos) - 1;		// convert to 0-based
-			if (request_params->segment_index < 0)
+			segment_index = ngx_atoi(start_pos, next_pos - start_pos) - 1;		// convert to 0-based
+			if (segment_index < 0)
 			{
 				ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
 					"parse_required_tracks: failed to parse the segment index");
 				return NGX_HTTP_BAD_REQUEST;
 			}
+			request_params->segment_index = segment_index;
 			request_params->request_type = REQUEST_TYPE_HLS_SEGMENT;
 		}
 		else

--- a/ngx_http_vod_request_parse.h
+++ b/ngx_http_vod_request_parse.h
@@ -15,7 +15,7 @@ enum {
 
 typedef struct {
 	int request_type;
-	int segment_index;
+	uint32_t segment_index;
 	uint32_t required_tracks[MEDIA_TYPE_COUNT];
 	uint32_t clip_to;
 	uint32_t clip_from;

--- a/test/main.py
+++ b/test/main.py
@@ -405,8 +405,8 @@ class BasicTestSuite(TestSuite):
         self.logTracker.assertContains('unsupported method')
 
     def testSegmentIdTooBig(self):
-        assertRequestFails(self.getUrl('/seg-3600-a1-v1.ts'), 400)
-        self.logTracker.assertContains('no frames were found')
+        assertRequestFails(self.getUrl('/seg-3600-a1-v1.ts'), 404)
+        self.logTracker.assertContains('requested segment index 3599 exceeds the segment count')
 
     def testNonExistingTracks(self):
         assertRequestFails(self.getUrl('/seg-1-a10-v10.ts'), 400)

--- a/vod/aes_encrypt.c
+++ b/vod/aes_encrypt.c
@@ -7,7 +7,7 @@ aes_encrypt_init(
 	write_callback_t callback,
 	void* callback_context,
 	const u_char* key,
-	int segment_index)
+	uint32_t segment_index)
 {
 	u_char iv[AES_BLOCK_SIZE];
 	u_char* p;

--- a/vod/aes_encrypt.h
+++ b/vod/aes_encrypt.h
@@ -28,7 +28,7 @@ vod_status_t aes_encrypt_init(
 	write_callback_t callback, 
 	void* callback_context, 
 	const u_char* key, 
-	int segment_index);
+	uint32_t segment_index);
 
 vod_status_t aes_encrypt_write(
 	aes_encrypt_context_t* ctx, 

--- a/vod/m3u8_builder.c
+++ b/vod/m3u8_builder.c
@@ -57,13 +57,13 @@ format_double(u_char* p, uint32_t n, uint32_t scale)
 }
 
 static vod_status_t
-build_required_tracks_string(request_context_t* request_context, mpeg_metadata_t* mpeg_metadata, uint32_t max_track_index, vod_str_t* required_tracks)
+build_required_tracks_string(request_context_t* request_context, mpeg_metadata_t* mpeg_metadata, vod_str_t* required_tracks)
 {
 	mpeg_stream_metadata_t* cur_stream;
 	mpeg_stream_metadata_t* streams_end;
 	u_char* buffer;
 
-	required_tracks->len = mpeg_metadata->streams.nelts * (sizeof("-v") - 1 + get_int_print_len(max_track_index + 1));
+	required_tracks->len = mpeg_metadata->streams.nelts * (sizeof("-v") - 1 + get_int_print_len(mpeg_metadata->max_track_index + 1));
 	buffer = vod_alloc(request_context->pool, required_tracks->len + 1);
 	if (buffer == NULL)
 	{
@@ -103,7 +103,7 @@ static u_char*
 append_segment_name(u_char* p, vod_str_t* segment_file_name_prefix, uint32_t segment_index, vod_str_t* required_tracks)
 {
 	p = vod_copy(p, segment_file_name_prefix->data, segment_file_name_prefix->len);
-	p = vod_sprintf(p, "%d", segment_index);
+	p = vod_sprintf(p, "%uD", segment_index);
 	p = vod_copy(p, required_tracks->data, required_tracks->len);
 	p = vod_copy(p, ".ts\n", sizeof(".ts\n") - 1);
 	return p;
@@ -120,7 +120,7 @@ append_extinf_tag(u_char* p, uint32_t duration, uint32_t scale)
 }
 
 static void
-append_iframe_string(void* context, int segment_index, uint32_t frame_duration, uint32_t frame_start, uint32_t frame_size)
+append_iframe_string(void* context, uint32_t segment_index, uint32_t frame_duration, uint32_t frame_start, uint32_t frame_size)
 {
 	append_iframe_context_t* ctx = (append_iframe_context_t*)context;
 
@@ -138,17 +138,12 @@ build_iframe_playlist_m3u8(
 	vod_str_t* result)
 {
 	append_iframe_context_t append_iframe_context;
-	mpeg_stream_metadata_t* cur_stream;
-	mpeg_stream_metadata_t* streams_end;
-	int64_t duration = 0;
 	uint32_t duration_millis;
 	uint32_t segment_count;
 	uint32_t iframe_length;
 	uint32_t total_size;
-	uint32_t key_frame_count = 0;
 	muxer_state_t muxer_state;
 	bool_t simulation_supported;
-	uint32_t max_track_index = 0;
 	vod_status_t rc;
 
 	// initialize the muxer
@@ -165,28 +160,15 @@ build_iframe_playlist_m3u8(
 		return VOD_BAD_REQUEST;
 	}
 
-	// get the max duration and track index
-	cur_stream = (mpeg_stream_metadata_t*)mpeg_metadata->streams.elts;
-	streams_end = cur_stream + mpeg_metadata->streams.nelts;
-	for (; cur_stream < streams_end; cur_stream++)
-	{
-		duration = MAX(duration, cur_stream->duration);
-		max_track_index = MAX(max_track_index, cur_stream->track_index);
-		if (cur_stream->media_type == MEDIA_TYPE_VIDEO)
-		{
-			key_frame_count += cur_stream->key_frame_count;
-		}
-	}
-
 	// build the required tracks string
-	rc = build_required_tracks_string(request_context, mpeg_metadata, max_track_index, &append_iframe_context.required_tracks);
+	rc = build_required_tracks_string(request_context, mpeg_metadata, &append_iframe_context.required_tracks);
 	if (rc != VOD_OK)
 	{
 		return rc;
 	}
 
 	// calculate the required buffer length
-	duration_millis = DIV_CEIL(duration, 90);
+	duration_millis = DIV_CEIL(mpeg_metadata->duration, 90);
 
 	segment_count = DIV_CEIL(duration_millis, segment_duration);
 
@@ -196,7 +178,7 @@ build_iframe_playlist_m3u8(
 
 	total_size =
 		conf->iframes_m3u8_header_len +
-		iframe_length * key_frame_count +
+		iframe_length * mpeg_metadata->video_key_frame_count +
 		sizeof(m3u8_footer);
 
 	// allocate the buffer
@@ -229,29 +211,16 @@ build_index_playlist_m3u8(
 	mpeg_metadata_t* mpeg_metadata,
 	vod_str_t* result)
 {
-	mpeg_stream_metadata_t* cur_stream;
-	mpeg_stream_metadata_t* streams_end;
 	vod_str_t required_tracks;
 	uint32_t segment_count;
 	uint32_t segment_index;
 	uint32_t total_size;
-	uint32_t max_track_index = 0;
 	uint32_t duration_millis;
-	int64_t duration = 0;
 	u_char* p;
 	vod_status_t rc;
 
-	// get max duration and track index
-	cur_stream = (mpeg_stream_metadata_t*)mpeg_metadata->streams.elts;
-	streams_end = cur_stream + mpeg_metadata->streams.nelts;
-	for (; cur_stream < streams_end; cur_stream++)
-	{
-		duration = MAX(duration, cur_stream->duration);
-		max_track_index = MAX(max_track_index, cur_stream->track_index);
-	}
-
 	// get the effective duration
-	duration_millis = DIV_CEIL(duration, 90);
+	duration_millis = DIV_CEIL(mpeg_metadata->duration, 90);
 
 	if (duration_millis <= clip_from)
 	{
@@ -263,7 +232,7 @@ build_index_playlist_m3u8(
 	duration_millis = MIN(duration_millis - clip_from, clip_to);
 
 	// build the required tracks string
-	rc = build_required_tracks_string(request_context, mpeg_metadata, max_track_index, &required_tracks);
+	rc = build_required_tracks_string(request_context, mpeg_metadata, &required_tracks);
 	if (rc != VOD_OK)
 	{
 		return rc;

--- a/vod/mp4_parser.h
+++ b/vod/mp4_parser.h
@@ -43,6 +43,9 @@ typedef struct {
 
 typedef struct {
 	vod_array_t streams;
+	int64_t duration;
+	uint32_t video_key_frame_count;
+	uint32_t max_track_index;
 } mpeg_metadata_t;
 
 // functions

--- a/vod/mpegts_encoder_filter.c
+++ b/vod/mpegts_encoder_filter.c
@@ -252,7 +252,7 @@ vod_status_t
 mpegts_encoder_init(
 	mpegts_encoder_state_t* state, 
 	request_context_t* request_context, 
-	int segment_index, 
+	uint32_t segment_index, 
 	write_callback_t write_callback, 
 	void* write_context)
 {
@@ -288,7 +288,7 @@ mpegts_encoder_init(
 }
 
 vod_status_t 
-mpegts_encoder_init_streams(mpegts_encoder_state_t* state, mpegts_encoder_init_streams_state_t* stream_state, int segment_index)
+mpegts_encoder_init_streams(mpegts_encoder_state_t* state, mpegts_encoder_init_streams_state_t* stream_state, uint32_t segment_index)
 {
 	stream_state->request_context = state->request_context;
 	stream_state->cur_pid = PCR_PID;

--- a/vod/mpegts_encoder_filter.h
+++ b/vod/mpegts_encoder_filter.h
@@ -49,11 +49,11 @@ extern const media_filter_t mpegts_encoder;
 vod_status_t mpegts_encoder_init(
 	mpegts_encoder_state_t* state, 
 	request_context_t* request_context, 
-	int segment_index,
+	uint32_t segment_index,
 	write_callback_t write_callback, 
 	void* write_context);
 
-vod_status_t mpegts_encoder_init_streams(mpegts_encoder_state_t* state, mpegts_encoder_init_streams_state_t* stream_state, int segment_index);
+vod_status_t mpegts_encoder_init_streams(mpegts_encoder_state_t* state, mpegts_encoder_init_streams_state_t* stream_state, uint32_t segment_index);
 vod_status_t mpegts_encoder_add_stream(mpegts_encoder_init_streams_state_t* stream_state, int media_type, unsigned* pid, unsigned* sid);
 void mpegts_encoder_finalize_streams(mpegts_encoder_init_streams_state_t* stream_state);
 

--- a/vod/muxer.c
+++ b/vod/muxer.c
@@ -22,7 +22,7 @@ vod_status_t
 muxer_init(
 	muxer_state_t* state, 
 	request_context_t* request_context,
-	int segment_index,
+	uint32_t segment_index,
 	mpeg_metadata_t* mpeg_metadata, 
 	read_cache_state_t* read_cache_state, 
 	write_callback_t write_callback, 
@@ -426,8 +426,8 @@ muxer_simulate_get_iframes(muxer_state_t* state, uint32_t segment_duration, get_
 	uint32_t first_frame_time = 0;
 	uint32_t end_time;
 	int64_t segment_end_dts;
-	int frame_segment_index = 0;
-	int segment_index = 1;
+	uint32_t frame_segment_index = 0;
+	uint32_t segment_index = 1;
 
 	segment_duration *= 90;			// convert to 90KHz
 	segment_end_dts = segment_duration;

--- a/vod/muxer.h
+++ b/vod/muxer.h
@@ -12,7 +12,7 @@
 // typedefs
 typedef void(*get_iframe_positions_callback_t)(
 	void* context, 
-	int segment_index, 
+	uint32_t segment_index, 
 	uint32_t frame_duration, 
 	uint32_t frame_start, 
 	uint32_t frame_size);
@@ -67,7 +67,7 @@ typedef struct {
 vod_status_t muxer_init(
 	muxer_state_t* state,
 	request_context_t* request_context,
-	int segment_index,
+	uint32_t segment_index,
 	mpeg_metadata_t* mpeg_metadata,
 	read_cache_state_t* read_cache_state,
 	write_callback_t write_callback,


### PR DESCRIPTION
the number of ts segments is derived from the track durations in the mp4 atoms. it is possible that the duration is for example 10 segments + 1/2 frame. in this case, the m3u8 will point to 11 segments, but the last segment will have no frames (the last frame is already included in segment number 10)
