### PR TITLE
misc changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 
 * MP4 files have to be "fast start" (the moov atom must be before the mdat atom)
 
+* Only AAC audio is supported (MP3 audio is not)
+
 * I-frames playlist generation is not supported when encryption is enabled
 
 * SAMPLE-AES encryption is not supported
@@ -71,11 +73,14 @@ To disable compiler optimizations (for debugging with gdb) add `CFLAGS="-g -O0"`
 ### Configuration directives
 
 #### vod
-* **syntax**: `vod`
+* **syntax**: `vod segmenter`
 * **default**: `n/a`
 * **context**: `location`
 
-Enables the nginx-vod module on the enclosing location.
+Enables the nginx-vod module on the enclosing location. 
+Currently the allowed values for `segmenter` are:
+1. `none` - serves the MP4 files as is
+2. `hls` - Apple HTTP Live Streaming packetizer
 
 #### vod_mode
 * **syntax**: `vod_mode mode`
@@ -83,14 +88,6 @@ Enables the nginx-vod module on the enclosing location.
 * **context**: `http`, `server`, `location`
 
 Sets the file access mode - local, remote or mapped
-
-#### vod_serve_files
-* **syntax**: `vod_serve_files on/off`
-* **default**: `on`
-* **context**: `http`, `server`, `location`
-
-When enabled requests that are not identified (e.g. .../index.m3u8, .../seg-1-v1-a1.ts etc.)
-will return the original media file.
 
 #### vod_segment_duration
 * **syntax**: `vod_segment_duration duration`

--- a/ngx_http_vod_conf.h
+++ b/ngx_http_vod_conf.h
@@ -6,13 +6,15 @@
 #include "vod/m3u8_builder.h"
 
 // typedefs
+struct request_params_s;
+
 typedef struct ngx_http_vod_loc_conf_s {
     struct ngx_http_vod_loc_conf_s *parent;
 
 	// config fields
 	ngx_str_t child_request_location;
+	ngx_int_t(*request_parser)(ngx_http_request_t *r, struct ngx_http_vod_loc_conf_s *conf, struct request_params_s* request_params);
 	ngx_int_t(*request_handler)(ngx_http_request_t *r);
-	ngx_flag_t serve_files;
 	ngx_uint_t segment_duration;
 	ngx_str_t secret_key;
 	ngx_shm_zone_t* moov_cache_zone;

--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -1407,11 +1407,11 @@ ngx_http_vod_handler(ngx_http_request_t *r)
 
 	original_uri = r->uri;
 
-	rc = parse_request_uri(r, conf, &request_params);
+	rc = conf->request_parser(r, conf, &request_params);
 	if (rc != NGX_OK)
 	{
 		ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-			"ngx_http_vod_handler: parse_request_uri failed %i", rc);
+			"ngx_http_vod_handler: request parser failed %i", rc);
 		return rc;
 	}
 

--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -201,8 +201,16 @@ parse_required_tracks(ngx_http_request_t* r, u_char* start_pos, u_char* end_pos,
 	return NGX_OK;
 }
 
+ngx_int_t
+parse_request_uri_serve_file(ngx_http_request_t *r, ngx_http_vod_loc_conf_t *conf, request_params_t* request_params)
+{
+	ngx_memzero(request_params, sizeof(*request_params));
+	request_params->request_type = REQUEST_TYPE_SERVE_FILE;
+	return NGX_OK;
+}
+
 ngx_int_t 
-parse_request_uri(ngx_http_request_t *r, ngx_http_vod_loc_conf_t *conf, request_params_t* request_params)
+parse_request_uri_hls(ngx_http_request_t *r, ngx_http_vod_loc_conf_t *conf, request_params_t* request_params)
 {
 	ngx_int_t rc;
 	u_char* start_pos = NULL;
@@ -291,20 +299,6 @@ parse_request_uri(ngx_http_request_t *r, ngx_http_vod_loc_conf_t *conf, request_
 	{
 		request_params->request_type = REQUEST_TYPE_HLS_ENCRYPTION_KEY;
 		
-		return NGX_OK;
-	}
-
-	if (conf->serve_files)
-	{
-		// the file name was not recognized, add it back to the URL
-		r->uri.data[r->uri.len] = '/';
-		r->uri.len++;
-		ngx_memcpy(r->uri.data + r->uri.len, start_pos, end_pos - start_pos);
-		r->uri.len += end_pos - start_pos;
-		r->uri.data[r->uri.len] = '\0';
-
-		request_params->request_type = REQUEST_TYPE_SERVE_FILE;
-
 		return NGX_OK;
 	}
 

--- a/ngx_http_vod_request_parse.h
+++ b/ngx_http_vod_request_parse.h
@@ -13,7 +13,7 @@ enum {
 	REQUEST_TYPE_SERVE_FILE,
 };
 
-typedef struct {
+typedef struct request_params_s {
 	int request_type;
 	uint32_t segment_index;
 	uint32_t required_tracks[MEDIA_TYPE_COUNT];
@@ -21,6 +21,8 @@ typedef struct {
 	uint32_t clip_from;
 } request_params_t;
 
-ngx_int_t parse_request_uri(ngx_http_request_t *r, ngx_http_vod_loc_conf_t *conf, request_params_t* request_params);
+ngx_int_t parse_request_uri_serve_file(ngx_http_request_t *r, ngx_http_vod_loc_conf_t *conf, request_params_t* request_params);
+
+ngx_int_t parse_request_uri_hls(ngx_http_request_t *r, ngx_http_vod_loc_conf_t *conf, request_params_t* request_params);
 
 #endif // _NGX_HTTP_VOD_REQUEST_PARSE_H_INCLUDED_

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,23 @@
+## nginx-vod-module tests
+
+the accompanied python scripts test the nginx-vod-module, each test script has an associated template file
+that contains environment specific parameters. the template file should copied and edited to match the 
+specific environment on which the tests are run.
+the tests assume that nginx is running with the accompanied nginx.conf file.
+
+### main.py
+
+sanity + coverage tests, e.g.:
+  1. bad request parameters
+  2. bad upstream responses
+  3. file not found
+
+in order to run the tests nginx should be compiled with the --with-debug switch
+  
+### hls_compare.py
+
+compares the nginx-vod hls implementation to some reference implementation
+
+### validate_iframes.py
+
+verifies using ffprobe that the byte ranges returned in an EXT-X-I-FRAMES-ONLY m3u8 indeed represent iframes

--- a/test/hls_compare_params.py.template
+++ b/test/hls_compare_params.py.template
@@ -1,5 +1,5 @@
 URL1_PREFIX = 'http://localhost:8001/mapped'
-URL1_PREFIXES = ['mapped','remote','mapped/enc','remote/enc']
+URL1_PREFIXES = ['mapped/hls','remote/hls','mapped/hls/enc','remote/hls/enc']
 URL1_SUFFIX = '/index.m3u8'
 URL2_PREFIX = 'http://some-other-server'
 URL2_SUFFIX = '/index.m3u8'

--- a/test/nginx.conf
+++ b/test/nginx.conf
@@ -84,9 +84,43 @@ http {
 		# non-encrypted
 		
 		# local
+		location /local/hls/content/ {
+			alias /web/content/;
+			vod hls;
+			vod_mode local;
+
+			add_header X-Me $hostname;
+			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
+			expires 100d;
+		}
+
+		# mapped
+		location ~ ^/mapped/hls/p/\d+/(sp/\d+/)?serveFlavor/ {
+			vod hls;
+			vod_mode mapped;
+			vod_upstream kalapi;
+			vod_upstream_extra_args "pathOnly=1";
+
+			add_header X-Me $hostname;
+			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
+			expires 100d;
+		}
+
+		# remote
+		location ~ ^/remote/hls/p/\d+/(sp/\d+/)?serveFlavor/ {
+			vod hls;
+			vod_mode remote;
+			vod_upstream kalapi;
+
+			add_header X-Me $hostname;
+			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
+			expires 100d;
+		}
+
+		# local
 		location /local/content/ {
 			alias /web/content/;
-			vod;
+			vod none;
 			vod_mode local;
 
 			add_header X-Me $hostname;
@@ -96,7 +130,7 @@ http {
 
 		# mapped
 		location ~ ^/mapped/p/\d+/(sp/\d+/)?serveFlavor/ {
-			vod;
+			vod none;
 			vod_mode mapped;
 			vod_upstream kalapi;
 			vod_upstream_extra_args "pathOnly=1";
@@ -108,7 +142,7 @@ http {
 
 		# remote
 		location ~ ^/remote/p/\d+/(sp/\d+/)?serveFlavor/ {
-			vod;
+			vod none;
 			vod_mode remote;
 			vod_upstream kalapi;
 
@@ -120,7 +154,7 @@ http {
 		# tests local
 		location /tlocal/content/ {
 			alias /web/content/;
-			vod;
+			vod none;
 			vod_mode local;
 			vod_fallback_upstream testfallback;
 
@@ -131,7 +165,7 @@ http {
 
 		# tests mapped
 		location ~ ^/tmapped/p/\d+/(sp/\d+/)?serveFlavor/ {
-			vod;
+			vod none;
 			vod_mode mapped;
 			vod_upstream testapi;
 			vod_fallback_upstream testfallback;
@@ -144,7 +178,7 @@ http {
 
 		# tests remote
 		location ~ ^/tremote/p/\d+/(sp/\d+/)?serveFlavor/ {
-			vod;
+			vod none;
 			vod_mode remote;
 			vod_upstream testapi;
 
@@ -153,12 +187,48 @@ http {
 			expires 100d;
 		}
 
+		# tests local hls
+		location /tlocal/hls/content/ {
+			alias /web/content/;
+			vod hls;
+			vod_mode local;
+			vod_fallback_upstream testfallback;
+
+			add_header X-Me $hostname;
+			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
+			expires 100d;
+		}
+
+		# tests mapped hls
+		location ~ ^/tmapped/hls/p/\d+/(sp/\d+/)?serveFlavor/ {
+			vod hls;
+			vod_mode mapped;
+			vod_upstream testapi;
+			vod_fallback_upstream testfallback;
+			vod_upstream_extra_args "pathOnly=1";
+
+			add_header X-Me $hostname;
+			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
+			expires 100d;
+		}
+
+		# tests remote hls
+		location ~ ^/tremote/hls/p/\d+/(sp/\d+/)?serveFlavor/ {
+			vod hls;
+			vod_mode remote;
+			vod_upstream testapi;
+
+			add_header X-Me $hostname;
+			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
+			expires 100d;
+		}
+		
 		# encrypted
 		
 		# local
-		location /local/enc/content/ {
+		location /local/hls/enc/content/ {
 			alias /web/content/;
-			vod;
+			vod hls;
 			vod_mode local;
 			vod_secret_key password;
 
@@ -168,8 +238,8 @@ http {
 		}
 
 		# mapped
-		location ~ ^/mapped/enc/p/\d+/(sp/\d+/)?serveFlavor/ {
-			vod;
+		location ~ ^/mapped/hls/enc/p/\d+/(sp/\d+/)?serveFlavor/ {
+			vod hls;
 			vod_mode mapped;
 			vod_secret_key password;
 			vod_upstream kalapi;
@@ -181,8 +251,8 @@ http {
 		}
 
 		# remote
-		location ~ ^/remote/enc/p/\d+/(sp/\d+/)?serveFlavor/ {
-			vod;
+		location ~ ^/remote/hls/enc/p/\d+/(sp/\d+/)?serveFlavor/ {
+			vod hls;
 			vod_mode remote;
 			vod_secret_key password;
 			vod_upstream kalapi;
@@ -193,9 +263,9 @@ http {
 		}
 		
 		# tests local
-		location /tlocal/enc/content/ {
+		location /tlocal/hls/enc/content/ {
 			alias /web/content/;
-			vod;
+			vod hls;
 			vod_mode local;
 			vod_secret_key password;
 			vod_fallback_upstream testfallback;
@@ -206,8 +276,8 @@ http {
 		}
 
 		# tests mapped
-		location ~ ^/tmapped/enc/p/\d+/(sp/\d+/)?serveFlavor/ {
-			vod;
+		location ~ ^/tmapped/hls/enc/p/\d+/(sp/\d+/)?serveFlavor/ {
+			vod hls;
 			vod_mode mapped;
 			vod_secret_key password;
 			vod_upstream testapi;
@@ -220,8 +290,8 @@ http {
 		}
 
 		# tests remote
-		location ~ ^/tremote/enc/p/\d+/(sp/\d+/)?serveFlavor/ {
-			vod;
+		location ~ ^/tremote/hls/enc/p/\d+/(sp/\d+/)?serveFlavor/ {
+			vod hls;
 			vod_mode remote;
 			vod_secret_key password;
 			vod_upstream testapi;

--- a/test/validate_iframes.py
+++ b/test/validate_iframes.py
@@ -6,7 +6,7 @@ import os
 
 from validate_iframes_params import *
 
-SERVER_URL = 'http://localhost:8001/mapped'
+SERVER_URL = 'http://localhost:8001/mapped/hls'
 IFRAMES_URI = '/iframes.m3u8'
 
 class TestThread(stress_base.TestThreadBase):

--- a/vod/mp4_parser.c
+++ b/vod/mp4_parser.c
@@ -583,7 +583,7 @@ parse_stts_atom(atom_info_t* atom_info, trak_info_t* trak_info)
 	
 	for (; cur_entry < last_entry; cur_entry++)
 	{
-		if (accum_duration > end_time)
+		if (accum_duration >= end_time)
 		{
 			break;
 		}
@@ -615,9 +615,14 @@ parse_stts_atom(atom_info_t* atom_info, trak_info_t* trak_info)
 		
 		for (; sample_count != 0; sample_count--, frame_index++, accum_duration += sample_duration)
 		{
-			if (accum_duration < start_time || accum_duration >= end_time)
+			if (accum_duration < start_time)
 			{
 				continue;
+			}
+
+			if (accum_duration >= end_time)
+			{
+				break;
 			}
 
 			if (first_frame == UINT_MAX)
@@ -729,9 +734,14 @@ parse_ctts_atom(atom_info_t* atom_info, trak_info_t* trak_info)
 
 		for (; sample_count != 0; sample_count--, frame_index++)
 		{
-			if (frame_index < trak_info->first_frame || frame_index >= trak_info->last_frame)
+			if (frame_index < trak_info->first_frame)
 			{
 				continue;
+			}
+
+			if (frame_index >= trak_info->last_frame)
+			{
+				break;
 			}
 			
 			trak_info->frames_info[frame_index - trak_info->first_frame].pts += sample_duration;

--- a/vod/mp4_to_annexb_filter.c
+++ b/vod/mp4_to_annexb_filter.c
@@ -162,6 +162,7 @@ mp4_to_annexb_start_frame(void* context, output_frame_t* frame)
 	state->cur_state = STATE_PACKET_SIZE;
 	state->length_bytes_left = state->nal_packet_size_length;
 	state->packet_size_left = 0;
+	state->key_frame = frame->key;
 	state->frame_size_left = frame->original_size;		// not adding the aud packet since we're just about to write it
 	if (frame->key)
 	{
@@ -214,7 +215,7 @@ mp4_to_annexb_write(void* context, const u_char* buffer, uint32_t size)
 			case NAL_IDR_SLICE:
 			case NAL_SPS:
 			case NAL_PPS:
-				if (state->first_idr)
+				if (state->key_frame && state->first_idr)
 				{
 					state->frame_size_left -= state->sps_pps_size;
 					rc = state->next_filter->write(state->next_filter_context, state->sps_pps, state->sps_pps_size);

--- a/vod/mp4_to_annexb_filter.h
+++ b/vod/mp4_to_annexb_filter.h
@@ -20,6 +20,7 @@ typedef struct {
 	int cur_state;
 	bool_t first_idr;
 	bool_t first_frame_packet;
+	bool_t key_frame;
 	uint32_t length_bytes_left;
 	uint32_t packet_size_left;
 	int32_t frame_size_left;


### PR DESCRIPTION
initial support for multiple packagers
change the serve file support to run on a separate location than hls
stts / ctts parsing optimization - stop the loop when reaching the segment end (significant for CFR)
prevent the addition of SPS/PPS in non key frames (can happen only in corrupt files)
update tests
add readme for tests
