### PR TITLE
log message normalization and bug fixes

### DIFF
--- a/ngx_child_http_request.c
+++ b/ngx_child_http_request.c
@@ -49,7 +49,7 @@ ngx_http_vod_create_request(ngx_http_request_t *r)
 	ngx_chain_t *cl;
 	child_request_base_context_t* ctx;
 
-	ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_create_request started");
+	ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_create_request: started");
 	
 	// allocate a chain and associate the previously created request buffer
 	cl = ngx_alloc_chain_link(r->pool);
@@ -66,7 +66,7 @@ ngx_http_vod_create_request(ngx_http_request_t *r)
 
 	r->upstream->request_bufs = cl;
 
-	ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_create_request done %s", ctx->request_buffer->pos);
+	ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_create_request: done %s", ctx->request_buffer->pos);
 
 	return NGX_OK;
 }
@@ -80,7 +80,7 @@ ngx_http_vod_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
 static ngx_int_t
 ngx_http_vod_reinit_request(ngx_http_request_t *r)
 {
-	ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_reinit_request called");
+	ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_reinit_request: called");
 
 	return NGX_OK;
 }
@@ -240,7 +240,7 @@ ngx_http_vod_process_status_line(ngx_http_request_t *r)
 	size_t len;
 	ngx_int_t rc;
 
-	ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_process_status_line started");
+	ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_process_status_line: started");
 
 	u = r->upstream;
 
@@ -292,7 +292,7 @@ ngx_http_vod_process_status_line(ngx_http_request_t *r)
 static void
 ngx_http_vod_abort_request(ngx_http_request_t *r)
 {
-	ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_abort_request called");
+	ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_abort_request: called");
 	return;
 }
 
@@ -672,13 +672,13 @@ child_request_finished_handler(ngx_http_request_t *r, void *data, ngx_int_t rc)
 		if (u->state && u->state->status != NGX_HTTP_OK && u->state->status != NGX_HTTP_PARTIAL_CONTENT)
 		{
 			ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-				"upstream returned a bad status %ui", u->state->status);
+				"child_request_finished_handler: upstream returned a bad status %ui", u->state->status);
 			rc = NGX_HTTP_BAD_GATEWAY;
 		}
 		else if (u->length != 0)
 		{
 			ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-				"upstream connection was closed with %O bytes left to read", u->length);
+				"child_request_finished_handler: upstream connection was closed with %O bytes left to read", u->length);
 			rc = NGX_HTTP_BAD_GATEWAY;
 		}
 	}

--- a/ngx_file_reader.c
+++ b/ngx_file_reader.c
@@ -74,7 +74,7 @@ file_reader_init(
 
 		if (rc != NGX_HTTP_NOT_FOUND || clcf->log_not_found) 
 		{
-			ngx_log_error(level, state->log, of.err, "%s \"%s\" failed", of.failed, path->data);
+			ngx_log_error(level, state->log, of.err, "file_reader_init: %s \"%s\" failed", of.failed, path->data);
 		}
 
 		return rc;
@@ -82,10 +82,10 @@ file_reader_init(
 
 	if (!of.is_file) 
 	{
-		ngx_log_error(NGX_LOG_ERR, state->log, 0, "\"%s\" is not a file", path->data);
+		ngx_log_error(NGX_LOG_ERR, state->log, 0, "file_reader_init: \"%s\" is not a file", path->data);
 		if (ngx_close_file(of.fd) == NGX_FILE_ERROR)
 		{
-			ngx_log_error(NGX_LOG_ALERT, state->log, ngx_errno, ngx_close_file_n " \"%s\" failed", path->data);
+			ngx_log_error(NGX_LOG_ALERT, state->log, ngx_errno, "file_reader_init: " ngx_close_file_n " \"%s\" failed", path->data);
 		}
 
 		return NGX_HTTP_FORBIDDEN;
@@ -215,7 +215,7 @@ file_reader_enable_directio(file_reader_state_t* state)
 		if (ngx_directio_on(state->file.fd) == NGX_FILE_ERROR) 
 		{
 			ngx_log_error(NGX_LOG_ALERT, state->log, ngx_errno,
-				ngx_directio_on_n " \"%s\" failed", state->file.name.data);
+				"file_reader_enable_directio: " ngx_directio_on_n " \"%s\" failed", state->file.name.data);
 			return NGX_FILE_ERROR;
 		}
 

--- a/ngx_http_vod_conf.c
+++ b/ngx_http_vod_conf.c
@@ -37,6 +37,7 @@ ngx_http_vod_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 {
     ngx_http_vod_loc_conf_t *prev = parent;
     ngx_http_vod_loc_conf_t *conf = child;
+	size_t proxy_header_len;
 	u_char* p;
 	char* err;
 
@@ -154,8 +155,8 @@ ngx_http_vod_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 		conf->secret_key.len > 0 ? (char*)conf->encryption_key_file_name.data : NULL);
 
 	// combine the proxy header name and value to a single line
-	conf->proxy_header.len = conf->proxy_header_name.len + sizeof(": ") - 1 + conf->proxy_header_value.len + sizeof(CRLF);
-	conf->proxy_header.data = ngx_alloc(conf->proxy_header.len, cf->log);
+	proxy_header_len = conf->proxy_header_name.len + sizeof(": ") - 1 + conf->proxy_header_value.len + sizeof(CRLF);
+	conf->proxy_header.data = ngx_alloc(proxy_header_len, cf->log);
 	if (conf->proxy_header.data == NULL)
 	{
 		return NGX_CONF_ERROR;
@@ -166,6 +167,8 @@ ngx_http_vod_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 	p = ngx_copy(p, conf->proxy_header_value.data, conf->proxy_header_value.len);
 	*p++ = '\r';		*p++ = '\n';
 	*p = '\0';
+
+	conf->proxy_header.len = p - conf->proxy_header.data;
 
     return NGX_CONF_OK;
 }

--- a/ngx_http_vod_status.c
+++ b/ngx_http_vod_status.c
@@ -72,8 +72,8 @@ ngx_http_vod_status_handler(ngx_http_request_t *r)
 	ngx_stat_def_t* cur_stat;
 	ngx_str_t response;
 	u_char* p;
-	int cache_stats_len = 0;
-	int length;
+	size_t cache_stats_len = 0;
+	size_t length;
 
 	conf = ngx_http_get_module_loc_conf(r, ngx_http_vod_module);
 
@@ -126,8 +126,16 @@ ngx_http_vod_status_handler(ngx_http_request_t *r)
 	}
 
 	p = ngx_copy(p, status_postfix, sizeof(status_postfix)-1);
-
+	
 	response.len = p - response.data;
+	
+	if (response.len > length)
+	{
+		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+			"ngx_http_vod_status_handler: response length %uz exceeded allocated length %uz", 
+			response.len, length);
+		return NGX_HTTP_INTERNAL_SERVER_ERROR;
+	}
 
 	return send_single_buffer_response(r, &response, xml_content_type, sizeof(xml_content_type)-1);
 }

--- a/test/test_converage.py
+++ b/test/test_converage.py
@@ -1,0 +1,43 @@
+import sys
+import re
+import os
+
+_, nginxVodRoot, errorLog = sys.argv
+
+logMessages = []
+logPrefixes = set([])
+for root, dirs, files in os.walk(nginxVodRoot):
+    for name in files:
+        if os.path.splitext(name)[1] != '.c':
+            continue
+        for curLog in re.findall('(?:ngx|vod)_log_(?:debug|error)[^\(]*\([^\)]+\)', file(os.path.join(root, name), 'rb').read()):
+            logMessage = curLog.split(',')[3].strip()
+            if logMessage.endswith('")'):
+                logMessage = logMessage[:-1]
+            if logMessage.endswith('"'):
+                logMessage = logMessage[:-1]
+            if logMessage.startswith('"'):
+                logMessage = logMessage[1:]
+
+            if logMessage == 'const char *fmt':
+                continue
+
+            logPrefix = logMessage.split('%')[0]
+            logMessages.append((logPrefix, logMessage))
+            logPrefixes.add(logPrefix)
+
+errorLogData = file(errorLog, 'rb').read()
+foundPrefixes = {}
+for logPrefix in logPrefixes:
+    logPos = errorLogData.find(logPrefix)
+    if logPos > 0:
+        foundPrefixes[logPrefix] = errorLogData[(errorLogData.rfind('\n', 0, logPos) + 1):errorLogData.find('\n', logPos)]
+
+print 'not covered:'
+for logPrefix, logMessage in logMessages:
+    if not foundPrefixes.has_key(logPrefix):
+        print '\t' + logMessage
+
+print 'convered:'
+for curLine in foundPrefixes.values():
+    print '\t' + curLine[:140]

--- a/vod/m3u8_builder.h
+++ b/vod/m3u8_builder.h
@@ -7,7 +7,7 @@
 // constants
 #define MAX_ENCRYPTION_KEY_FILE_NAME_LEN (32)
 
-static const char m3u8_header_format[] = "#EXTM3U\n#EXT-X-TARGETDURATION:%d\n#EXT-X-ALLOW-CACHE:YES\n%s%s%s#EXT-X-VERSION:%d\n#EXT-X-MEDIA-SEQUENCE:1\n";
+static const char m3u8_header_format[] = "#EXTM3U\n#EXT-X-TARGETDURATION:%d\n#EXT-X-ALLOW-CACHE:YES\n#EXT-X-PLAYLIST-TYPE:VOD\n%s%s%s#EXT-X-VERSION:%d\n#EXT-X-MEDIA-SEQUENCE:1\n";
 static const char encryption_key_tag_prefix[] = "#EXT-X-KEY:METHOD=AES-128,URI=\"";
 static const char encryption_key_tag_postfix[] = "\"\n";
 static const char m3u8_extinf_format[] = "#EXTINF:%d.%d,\n";

--- a/vod/mp4_parser.c
+++ b/vod/mp4_parser.c
@@ -1690,7 +1690,7 @@ process_moov_atom_callback(void* ctx, atom_info_t* atom_info)
 	// parse the rest of the trak atoms
 	for (cur_parser = context->parsers; cur_parser->parse; cur_parser++)
 	{
-		vod_log_debug1(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0, "running parser %i", parser_index++);
+		vod_log_debug1(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0, "process_moov_atom_callback: running parser %i", parser_index++);
 		rc = cur_parser->parse((atom_info_t*)((u_char*)&trak_atom_infos + cur_parser->offset), &trak_info);
 		if (rc != VOD_OK)
 		{

--- a/vod/mp4_to_annexb_filter.c
+++ b/vod/mp4_to_annexb_filter.c
@@ -130,6 +130,14 @@ mp4_to_annexb_init(
 		}
 	}
 	
+	if (sps_pps_pos - state->sps_pps != state->sps_pps_size)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"mp4_to_annexb_init: actual sps/pps size %uz is different than calculated size %uD", 
+			(size_t)(sps_pps_pos - state->sps_pps), state->sps_pps_size);
+		return VOD_UNEXPECTED;
+	}
+	
 	vod_log_buffer(VOD_LOG_DEBUG_LEVEL, request_context->log, 0, "mp4_to_annexb_init: parsed extra data ", state->sps_pps, state->sps_pps_size);
 	return VOD_OK;
 }


### PR DESCRIPTION
remove null byte from loop prevention header
save the moov atom to cache only if it's successfully parsed
take the clipTo/From in consideration when validating the TS segment index
add validations that calculated string lengths are not being overflown
test the segment durations in hls_compare
use version 3 m3u8 for the media playlists + fixed point 3 digits durations
