### PR TITLE
support non-fast-start mp4 files

### DIFF
--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -225,7 +225,7 @@ ngx_http_vod_parse_hls_uri(ngx_http_request_t *r, ngx_http_vod_loc_conf_t *conf,
 	if (rc != NGX_OK)
 	{
 		ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-			"parse_request_uri: ngx_http_vod_extract_uri_tokens failed %i", rc);
+			"ngx_http_vod_parse_hls_uri: ngx_http_vod_extract_uri_tokens failed %i", rc);
 		return rc;
 	}
 
@@ -236,7 +236,7 @@ ngx_http_vod_parse_hls_uri(ngx_http_request_t *r, ngx_http_vod_loc_conf_t *conf,
 		if (ngx_memcmp(start_pos, conf->m3u8_config.segment_file_name_prefix.data, conf->m3u8_config.segment_file_name_prefix.len) != 0)
 		{
 			ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, 
-				"parse_request_uri: unidentified ts request");
+				"ngx_http_vod_parse_hls_uri: unidentified ts request");
 			return NGX_HTTP_BAD_REQUEST;
 		}
 		start_pos += conf->m3u8_config.segment_file_name_prefix.len;
@@ -246,7 +246,7 @@ ngx_http_vod_parse_hls_uri(ngx_http_request_t *r, ngx_http_vod_loc_conf_t *conf,
 		if (rc != NGX_OK)
 		{
 			ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-				"parse_request_uri: ngx_http_vod_parse_required_tracks failed %i (1)", rc);
+				"ngx_http_vod_parse_hls_uri: ngx_http_vod_parse_required_tracks failed %i (1)", rc);
 			return rc;
 		}
 
@@ -272,7 +272,7 @@ ngx_http_vod_parse_hls_uri(ngx_http_request_t *r, ngx_http_vod_loc_conf_t *conf,
 		else
 		{
 			ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-				"parse_request_uri: unidentified m3u8 request");
+				"ngx_http_vod_parse_hls_uri: unidentified m3u8 request");
 			return NGX_HTTP_BAD_REQUEST;
 		}
 
@@ -286,7 +286,7 @@ ngx_http_vod_parse_hls_uri(ngx_http_request_t *r, ngx_http_vod_loc_conf_t *conf,
 		if (rc != NGX_OK)
 		{
 			ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-				"parse_request_uri: ngx_http_vod_parse_required_tracks failed %i (2)", rc);
+				"ngx_http_vod_parse_hls_uri: ngx_http_vod_parse_required_tracks failed %i (2)", rc);
 			return rc;
 		}
 
@@ -302,5 +302,7 @@ ngx_http_vod_parse_hls_uri(ngx_http_request_t *r, ngx_http_vod_loc_conf_t *conf,
 		return NGX_OK;
 	}
 
+	ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+		"ngx_http_vod_parse_hls_uri: unidentified request");
 	return NGX_HTTP_BAD_REQUEST;
 }

--- a/test/verify_test_entries.py
+++ b/test/verify_test_entries.py
@@ -1,4 +1,5 @@
 import urllib2
+import httplib
 import sys
 import os
 
@@ -30,8 +31,6 @@ for curLine in sys.stdin:
     if len(curLine) == 0:
         break
     refId, uri, expectedStatusCode, message = curLine.split(' ', 3)
-    if refId == 'TRUNCATED_MDAT':
-        continue        # hangs
     print 'testing %s %s' % (refId, uri)
     logTracker = LogTracker()
     try:
@@ -40,6 +39,8 @@ for curLine in sys.stdin:
         f.read()
     except urllib2.HTTPError, e:
         statusCode = e.getcode()
+    except httplib.BadStatusLine:
+        statusCode = 0
     if message != 'None':
         logTracker.assertContains(message)
     assert(expectedStatusCode == str(statusCode))


### PR DESCRIPTION
in addition:
1. support mp4 with extra QT audio fields
2. bug fix for hanging connections after error - need to call
ngx_http_run_posted_requests in the aio completion callback
