### PR TITLE
avoid the need for an nginx core patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,6 @@ without the overhead of short segments for the whole duration of the video
 
 * Tested on Linux only
 
-### Nginx patch
-
-The module depends on a small patch to the nginx code - in src/http/ngx_http_upstream.c, in ngx_http_upstream_process_body_in_memory replace:
-	for ( ;; ) {
-with:
-	while (u->length) {
-	
-The problem with the existing code is that when the upstream buffer size matches the response size exactly, the upstream module fails with 'upstream buffer is too small to read response' instead of completing the result successfully.
-Since the nginx-vod-module performs range requests and sets the upstream buffer to the exact response size, this error always happens.
-
 ### Build
 
 cd to NGINX source directory and execute:
@@ -602,19 +592,9 @@ The name of the manifest file (has no extension).
 		}
 	}
 
+	
 ### Copyright & License
 
-Copyright (C) 2006-2014  Kaltura Inc.
+All code in this project is released under the [AGPLv3 license](http://www.gnu.org/licenses/agpl-3.0.html) unless a different license for a particular library is specified in the applicable library path. 
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+Copyright © Kaltura Inc. All rights reserved.

--- a/ngx_buffer_cache.c
+++ b/ngx_buffer_cache.c
@@ -407,7 +407,9 @@ ngx_buffer_cache_store_gather(
 		entry = ngx_buffer_cache_rbtree_lookup(&cache->rbtree, key, hash);
 		if (entry != NULL)
 		{
-			goto error;
+			cache->stats.store_exists++;
+			ngx_shmtx_unlock(&shpool->mutex);
+			return 0;
 		}
 
 		// enable the reset flag before we start making any changes

--- a/ngx_buffer_cache.h
+++ b/ngx_buffer_cache.h
@@ -12,6 +12,7 @@ typedef struct {
 	ngx_atomic_t store_ok;
 	ngx_atomic_t store_bytes;
 	ngx_atomic_t store_err;
+	ngx_atomic_t store_exists;
 	ngx_atomic_t fetch_hit;
 	ngx_atomic_t fetch_bytes;
 	ngx_atomic_t fetch_miss;

--- a/ngx_child_http_request.h
+++ b/ngx_child_http_request.h
@@ -28,6 +28,12 @@ typedef struct {
 } ngx_child_request_buffers_t;
 
 // request initiation function
+
+// IMPORTANT NOTE: due to the implementation of ngx_http_upstream_process_body_in_memory, and in order to
+//		avoid memory copy operations, this function assumes that the buffer passed to it has a size of 
+//		at least max_response_length + 1 (unlike max_response_length like one would expect)
+//		this issue is discussed in http://trac.nginx.org/nginx/ticket/680
+
 ngx_int_t ngx_child_request_start(
 	ngx_http_request_t *r,
 	ngx_child_request_buffers_t* buffers,

--- a/ngx_http_vod_status.c
+++ b/ngx_http_vod_status.c
@@ -30,6 +30,7 @@ static ngx_http_vod_stat_def_t buffer_cache_stat_defs[] = {
 	DEFINE_STAT(store_ok),
 	DEFINE_STAT(store_bytes),
 	DEFINE_STAT(store_err),
+	DEFINE_STAT(store_exists),
 	DEFINE_STAT(fetch_hit),
 	DEFINE_STAT(fetch_bytes),
 	DEFINE_STAT(fetch_miss),

--- a/test/uri_compare.py
+++ b/test/uri_compare.py
@@ -14,6 +14,7 @@ class TestThread(stress_base.TestThreadBase):
 		request = urllib2.Request(url)
 		try:
 			f = urllib2.urlopen(request)
+			return f.getcode(), f.read()
 		except urllib2.HTTPError, e:
 			return e.getcode(), e.read()			
 		except urllib2.URLError, e:
@@ -25,7 +26,6 @@ class TestThread(stress_base.TestThreadBase):
 		except socket.error, e:
 			self.writeOutput('Error: got socket error %s %s' % (url, e))
 			return 0, ''
-		return f.getcode(), f.read()
 		
 	def runTest(self, uri):		
 		url1 = URL1_BASE + uri

--- a/vod/read_cache.c
+++ b/vod/read_cache.c
@@ -55,7 +55,7 @@ read_cache_get_read_buffer(read_cache_state_t* state, uint64_t offset, uint64_t*
 	// make sure the buffer is allocated
 	if (target_buffer->buffer == NULL)
 	{
-		target_buffer->buffer = vod_memalign(state->request_context->pool, state->buffer_size, state->alignment);
+		target_buffer->buffer = vod_memalign(state->request_context->pool, state->buffer_size + 1, state->alignment);
 		if (target_buffer->buffer == NULL)
 		{
 			vod_log_debug0(VOD_LOG_DEBUG_LEVEL, state->request_context->log, 0,


### PR DESCRIPTION
also:
1. when storing an item to cache that already exists dont count it as store error (use a separate counter)
2. check the http status code once the headers are received (no need to read the body in case of error)
3. change the message 'upstream request failed' to be debug only - in case of a real error (not client-disconnected) some previous message will already be printed
4. update the license & copyright text in readme.md
