### PR TITLE
stat improvements

### DIFF
--- a/ngx_buffer_cache.c
+++ b/ngx_buffer_cache.c
@@ -519,6 +519,22 @@ ngx_buffer_cache_get_stats(
 	ngx_shmtx_unlock(&shpool->mutex);
 }
 
+void
+ngx_buffer_cache_reset_stats(ngx_shm_zone_t *shm_zone)
+{
+	ngx_buffer_cache_t *cache;
+	ngx_slab_pool_t *shpool;
+
+	shpool = (ngx_slab_pool_t *)shm_zone->shm.addr;
+	cache = shpool->data;
+
+	ngx_shmtx_lock(&shpool->mutex);
+
+	ngx_memzero(&cache->stats, sizeof(cache->stats));
+
+	ngx_shmtx_unlock(&shpool->mutex);
+}
+
 ngx_shm_zone_t* 
 ngx_buffer_cache_create_zone(ngx_conf_t *cf, ngx_str_t *name, size_t size, void *tag)
 {

--- a/ngx_buffer_cache.h
+++ b/ngx_buffer_cache.h
@@ -48,6 +48,8 @@ void ngx_buffer_cache_get_stats(
 	ngx_shm_zone_t *shm_zone,
 	ngx_buffer_cache_stats_t* stats);
 
+void ngx_buffer_cache_reset_stats(ngx_shm_zone_t *shm_zone);
+
 ngx_shm_zone_t* ngx_buffer_cache_create_zone(ngx_conf_t *cf, ngx_str_t *name, size_t size, void *tag);
 
 #endif // _NGX_BUFFER_CACHE_H_INCLUDED_

--- a/ngx_perf_counters.h
+++ b/ngx_perf_counters.h
@@ -57,8 +57,11 @@ typedef struct timeval ngx_tick_count_t;
 		ngx_atomic_fetch_add(&state->counters[type].count, 1);		\
 		if (__delta > state->counters[type].max)					\
 		{															\
+			struct timeval __tv;									\
+			ngx_gettimeofday(&__tv);								\
 			state->counters[type].max = __delta;					\
-			state->counters[type].max_time = ngx_time();			\
+			state->counters[type].max_time = __tv.tv_sec;			\
+			state->counters[type].max_pid = ngx_pid;				\
 		}															\
 	}
 
@@ -96,6 +99,7 @@ typedef struct {
 	ngx_atomic_t count;
 	ngx_atomic_t max;
 	ngx_atomic_t max_time;
+	ngx_atomic_t max_pid;
 } ngx_perf_counter_t;
 
 typedef struct {


### PR DESCRIPTION
- add a reset parameter to the status page
- add the worker pid in which the maximum value was measured
- don't use the cached nginx time for max_time (this time may be wrong in case the process was stuck)
