### PR TITLE
reduce the cache lock time

### DIFF
--- a/ngx_buffer_cache_internal.h
+++ b/ngx_buffer_cache_internal.h
@@ -8,8 +8,8 @@
 #define container_of(ptr, type, member) (type *)((char *)(ptr) - offsetof(type, member))
 
 // constants
-#define CACHE_LOCK_EXPIRATION (10)
-#define ENTRY_LOCK_EXPIRATION (60)
+#define CACHE_LOCK_EXPIRATION (5)
+#define ENTRY_LOCK_EXPIRATION (5)
 #define ENTRIES_ALLOC_MARGIN (1024)		// 1K entries ~= 100KB, we reserve this space to make sure allocating entries does not become the bottleneck
 #define BUFFER_ALIGNMENT (16)
 

--- a/test/uri_compare.py
+++ b/test/uri_compare.py
@@ -68,7 +68,7 @@ class TestThread(stress_base.TestThreadBase):
 		if str(code1) != '200':
 			self.writeOutput('Notice: got status code %s' % (code1))
 		
-		if url1.split('?')[0].rsplit('.', 1)[-1] in set(['m3u8']):
+		if url1.split('?')[0].rsplit('.', 1)[-1] in set(['m3u8', 'mpd']):
 			body1 = body1.replace(URL1_BASE, URL2_BASE)
 			body1 = body1.replace('-a1-v1', '-v1-a1')
 			body2 = body2.replace('-a1-v1', '-v1-a1')


### PR DESCRIPTION
store takes less than 20ms and fetch takes less than 10ms, so 5 seconds
should suffice. reducing the lock time prevents a case where a frequently
requested long flavor prevents the storing of new flavors to the moov
cache.