### PR TITLE
uri escaping fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Sets the value of the HTTP host header that should be sent to the upstream (remo
 * **context**: `http`, `server`, `location`
 
 Extra query string arguments that should be added to the upstream request (remote/mapped modes only).
+The parameter value can contain variables.
 
 #### vod_connect_timeout
 * **syntax**: `vod_connect_timeout timeout`
@@ -490,6 +491,14 @@ Sets the timeout in milliseconds for reading data from the upstream.
 * **context**: `http`, `server`, `location`
 
 Configures the size and shared memory object name of the drm info cache.
+
+#### vod_drm_request_uri
+* **syntax**: `vod_drm_request_uri uri`
+* **default**: `$uri`
+* **context**: `http`, `server`, `location`
+
+Sets the uri of drm info requests, the parameter value can contain variables.
+In case of multi url, $uri will one of the sub URLs (a separate drm info request is issued per sub URL)
 
 ### Configuration directives - DASH
 

--- a/ngx_child_http_request.h
+++ b/ngx_child_http_request.h
@@ -49,6 +49,7 @@ typedef struct {
 	ngx_str_t extra_headers;
 	ngx_flag_t proxy_range;
 	ngx_flag_t proxy_accept_encoding;
+	ngx_flag_t escape_uri;
 } ngx_child_request_params_t;
 
 // Note: the purpose of this struct is to reuse the request & headers buffers between several 

--- a/ngx_http_vod_conf.c
+++ b/ngx_http_vod_conf.c
@@ -150,6 +150,10 @@ ngx_http_vod_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 	{
 		conf->drm_info_cache_zone = prev->drm_info_cache_zone;
 	}
+	if (conf->drm_request_uri == NULL) 
+	{
+		conf->drm_request_uri = prev->drm_request_uri;
+	}
 
 	ngx_conf_merge_str_value(conf->clip_to_param_name, prev->clip_to_param_name, "clipTo");
 	ngx_conf_merge_str_value(conf->clip_from_param_name, prev->clip_from_param_name, "clipFrom");
@@ -782,6 +786,13 @@ ngx_command_t ngx_http_vod_commands[] = {
 	offsetof(ngx_http_vod_loc_conf_t, drm_info_cache_zone),
 	NULL },
 
+	{ ngx_string("vod_drm_request_uri"),
+	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+	ngx_http_set_complex_value_slot,
+	NGX_HTTP_LOC_CONF_OFFSET,
+	offsetof(ngx_http_vod_loc_conf_t, drm_request_uri),
+	NULL },
+	
 	// request format settings
 	{ ngx_string("vod_clip_to_param_name"),
 	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,

--- a/ngx_http_vod_conf.h
+++ b/ngx_http_vod_conf.h
@@ -44,6 +44,7 @@ struct ngx_http_vod_loc_conf_s {
 	ngx_http_upstream_conf_t drm_upstream;
 	size_t drm_max_info_length;
 	ngx_shm_zone_t* drm_info_cache_zone;
+	ngx_http_complex_value_t *drm_request_uri;
 
 	ngx_str_t clip_to_param_name;
 	ngx_str_t clip_from_param_name;


### PR DESCRIPTION
1. need to escape uri that derive from r->uri, otherwise uris with spaces wont work.
2. use unparsed_uri without any escaping in dump requests so that Akamai G2O validation will not break when performing fallback between DCs
3. make the drm info uri configurable