### PR TITLE
Fix warnings treaded as errors when compiling

### DIFF
--- a/ngx_simple_json_parser.c
+++ b/ngx_simple_json_parser.c
@@ -1,4 +1,5 @@
 #include "ngx_simple_json_parser.h"
+#include <ctype.h>
 
 // macros
 #define EXPECT_CHAR(state, ch)										\

--- a/ngx_simple_json_parser.h
+++ b/ngx_simple_json_parser.h
@@ -3,6 +3,7 @@
 
 // includes
 #include <ngx_core.h>
+#include <ctype.h>
 
 // macros
 #define NGX_GUID_LEN (16)

--- a/ngx_simple_json_parser.h
+++ b/ngx_simple_json_parser.h
@@ -3,7 +3,6 @@
 
 // includes
 #include <ngx_core.h>
-#include <ctype.h>
 
 // macros
 #define NGX_GUID_LEN (16)

--- a/vod/mss/mss_playready.c
+++ b/vod/mss/mss_playready.c
@@ -50,7 +50,6 @@ mss_playready_write_protection_tag(void* context, u_char* p, mpeg_metadata_t* mp
 	// XXXX taking only the first stream
 	mp4_encrypt_info_t* drm_info = (mp4_encrypt_info_t*)mpeg_metadata->first_stream->file_info.drm_info;
 	mp4_encrypt_system_info_t* cur_info;
-	vod_str_t wrm_header;
 	vod_str_t base64;
 
 	p = vod_copy(p, VOD_MSS_PLAYREADY_PROTECTION_PREFIX, sizeof(VOD_MSS_PLAYREADY_PROTECTION_PREFIX) - 1);


### PR DESCRIPTION
Not able to build nginx debian package under ubuntu 14.04.
This fix removes compile warnings that were treated as errors due to `-Werror`
