### PR TITLE
fix iframes playlist when clipFrom is used

### DIFF
--- a/vod/common.h
+++ b/vod/common.h
@@ -62,8 +62,13 @@
 #define VOD_HAVE_LIB_AV_FILTER NGX_HAVE_LIB_AV_FILTER
 
 // macros
+#ifndef MIN
 #define MIN(x, y) ngx_min(x, y)
+#endif // MIN
+
+#ifndef MAX
 #define MAX(x, y) ngx_max(x, y)
+#endif // MAX
 
 // errors codes
 #define  VOD_OK         NGX_OK

--- a/vod/hls/buffer_filter.c
+++ b/vod/hls/buffer_filter.c
@@ -237,6 +237,9 @@ buffer_filter_simulated_force_flush(buffer_filter_t* state)
 {
 	if (state->cur_state == STATE_FRAME_FLUSHED)
 	{
+		vod_log_debug2(VOD_LOG_DEBUG_LEVEL, state->request_context->log, 0,
+			"buffer_filter_simulated_force_flush: writing %uD dts %uL", state->cur_frame.original_size, state->cur_frame.dts);
+
 		state->next_filter->simulated_write(state->next_filter_context, &state->cur_frame);
 		state->cur_state = STATE_INITIAL;
 	}

--- a/vod/hls/hls_muxer.c
+++ b/vod/hls/hls_muxer.c
@@ -57,6 +57,7 @@ hls_muxer_init(
 		cur_stream->cur_frame = cur_stream_metadata->frames;
 		cur_stream->last_frame = cur_stream->cur_frame + cur_stream_metadata->frame_count;
 		cur_stream->first_frame_time_offset = cur_stream_metadata->first_frame_time_offset;
+		cur_stream->clip_from_frame_offset = cur_stream_metadata->clip_from_frame_offset;
 		cur_stream->next_frame_time_offset = cur_stream->first_frame_time_offset;
 		cur_stream->next_frame_dts = rescale_time(cur_stream->next_frame_time_offset, cur_stream->timescale, HLS_TIMESCALE);
 		cur_stream->first_frame_offset = cur_stream_metadata->frame_offsets;
@@ -452,7 +453,7 @@ hls_muxer_simulation_set_segment_limit(
 
 	for (cur_stream = state->first_stream; cur_stream < state->last_stream; cur_stream++)
 	{
-		cur_stream->segment_limit = (segment_end * cur_stream->timescale) / timescale;
+		cur_stream->segment_limit = (segment_end * cur_stream->timescale) / timescale - cur_stream->clip_from_frame_offset;
 	}
 }
 

--- a/vod/hls/hls_muxer.h
+++ b/vod/hls/hls_muxer.h
@@ -34,6 +34,7 @@ typedef struct {
 	uint64_t next_frame_time_offset;
 	uint64_t next_frame_dts;
 	uint64_t segment_limit;		// used only for iframes
+	int32_t clip_from_frame_offset;
 	
 	// frame offsets
 	uint64_t* first_frame_offset;

--- a/vod/mp4_parser.c
+++ b/vod/mp4_parser.c
@@ -310,6 +310,7 @@ typedef struct {
 	uint32_t first_frame;
 	uint32_t last_frame;
 	uint64_t first_frame_time_offset;
+	int32_t clip_from_frame_offset;
 	input_frame_t* frames;
 	uint64_t* frame_offsets;
 	uint32_t frame_count;
@@ -867,6 +868,8 @@ mp4_parser_parse_stts_atom(atom_info_t* atom_info, frames_parse_context_t* conte
 		// calculate the clip from duration
 		skip_count = DIV_CEIL(clip_from - accum_duration, sample_duration);
 		clip_from_accum_duration = accum_duration + skip_count * sample_duration;
+
+		context->clip_from_frame_offset = clip_from_accum_duration - clip_from;
 	}
 
 	// skip to the sample containing the start time
@@ -2762,6 +2765,7 @@ mp4_parser_parse_frames(
 		result_stream->total_frames_duration = context.total_frames_duration;
 		result_stream->first_frame_index = context.first_frame;
 		result_stream->first_frame_time_offset = context.first_frame_time_offset;
+		result_stream->clip_from_frame_offset = context.clip_from_frame_offset;
 
 		// copy raw atoms
 		if ((request_context->parse_type & PARSE_FLAG_SAVE_RAW_ATOMS) != 0)

--- a/vod/mp4_parser.h
+++ b/vod/mp4_parser.h
@@ -190,6 +190,7 @@ typedef struct {
 	uint64_t total_frames_duration;
 	uint32_t first_frame_index;
 	uint64_t first_frame_time_offset;
+	int32_t clip_from_frame_offset;
 	raw_atom_t raw_atoms[RTA_COUNT];
 } mpeg_stream_metadata_t;
 


### PR DESCRIPTION
the simulation starts from the first frame while the segments are actually cut starting from the clipFrom position. we need to compensate for the small diff between the requested clipFrom and the timestamp of the first frame after it