### PR TITLE
Mp4 clipping bug fixes 2

### DIFF
--- a/ngx_child_http_request.h
+++ b/ngx_child_http_request.h
@@ -37,7 +37,7 @@
 
 
 // typedefs
-typedef void (*ngx_child_request_callback_t)(void* context, ngx_int_t rc, ngx_buf_t* response);
+typedef void (*ngx_child_request_callback_t)(void* context, ngx_int_t rc, off_t content_length, ngx_buf_t* response);
 
 typedef struct {
 	ngx_uint_t method;

--- a/ngx_file_reader.c
+++ b/ngx_file_reader.c
@@ -333,6 +333,12 @@ ngx_file_reader_dump_file_part(ngx_file_reader_state_t* state, off_t start, off_
 	b->file_pos = start;
 	if (end != 0)
 	{
+		if (end > state->file_size)
+		{
+			ngx_log_error(NGX_LOG_ERR, state->log, ngx_errno,
+				"ngx_file_reader_dump_file_part: end offset %O exceeds file size %O, probably a truncated file", end, state->file_size);
+			return NGX_HTTP_NOT_FOUND;
+		}
 		b->file_last = end;
 	}
 	else

--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -1799,7 +1799,7 @@ ngx_http_vod_run_state_machine(ngx_http_vod_ctx_t *ctx)
 			rc = ngx_http_send_special(ctx->submodule_context.r, NGX_HTTP_LAST);
 			if (rc != NGX_OK && rc != NGX_AGAIN)
 			{
-				ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+				ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ctx->submodule_context.request_context.log, 0,
 					"ngx_http_vod_run_state_machine: ngx_http_send_special failed %i", rc);
 				return rc;
 			}
@@ -1873,7 +1873,7 @@ ngx_http_vod_run_state_machine(ngx_http_vod_ctx_t *ctx)
 		rc = ngx_http_send_special(ctx->submodule_context.r, NGX_HTTP_LAST);
 		if (rc != NGX_OK && rc != NGX_AGAIN)
 		{
-			ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+			ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ctx->submodule_context.request_context.log, 0,
 				"ngx_http_vod_run_state_machine: ngx_http_send_special failed %i", rc);
 			return rc;
 		}

--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -296,7 +296,7 @@ ngx_http_vod_init_aes_encryption(ngx_http_vod_ctx_t *ctx, write_callback_t write
 ////// DRM
 
 static void
-ngx_http_vod_drm_info_request_finished(void* context, ngx_int_t rc, ngx_buf_t* response)
+ngx_http_vod_drm_info_request_finished(void* context, ngx_int_t rc, off_t content_length, ngx_buf_t* response)
 {
 	ngx_http_vod_loc_conf_t *conf;
 	ngx_http_vod_ctx_t *ctx;
@@ -316,7 +316,7 @@ ngx_http_vod_drm_info_request_finished(void* context, ngx_int_t rc, ngx_buf_t* r
 	ngx_perf_counter_end(ctx->perf_counters, ctx->perf_counter_context, PC_GET_DRM_INFO);
 
 	drm_info.data = response->pos;
-	drm_info.len = response->last - response->pos;
+	drm_info.len = content_length;
 	*response->last = '\0';		// this is ok since ngx_child_http_request always allocates the content-length + 1
 
 	ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_drm_info_request_finished: result %V", &drm_info);
@@ -506,6 +506,11 @@ ngx_http_vod_read_moov_atom(ngx_http_vod_ctx_t *ctx)
 
 				ngx_memcpy(ctx->ftyp_ptr, ftyp_ptr, ftyp_size);
 				ctx->ftyp_size = ftyp_size;
+			}
+			else
+			{
+				ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ctx->submodule_context.request_context.log, 0,
+					"ngx_http_vod_read_moov_atom: ftyp atom not found");
 			}
 		}
 
@@ -1584,6 +1589,10 @@ ngx_http_vod_send_clip_header(ngx_http_vod_ctx_t *ctx)
 	ngx_chain_t* out;
 	size_t response_size;
 	ngx_int_t rc;
+	off_t range_start;
+	off_t range_end;
+	off_t header_size;
+	off_t mdat_size;
 
 	rc = mp4_clipper_build_header(
 		&ctx->submodule_context.request_context,
@@ -1634,6 +1643,47 @@ ngx_http_vod_send_clip_header(ngx_http_vod_ctx_t *ctx)
 		ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
 			"ngx_http_vod_send_clip_header: ngx_http_output_filter failed %i", rc);
 		return rc;
+	}
+
+	if (ctx->submodule_context.conf->request_handler == ngx_http_vod_remote_request_handler && 
+		ctx->submodule_context.r->headers_in.range)
+	{
+		// in case of range request in remote mode, apply the requested range to the mdat dump offsets.
+		// nginx's range filter module does not touch the dumped part since it is written in the context
+		// a subrequest. 
+
+		// TODO: apply the range on the mp4 header as well and return 206, to avoid making assumptions on
+		//		nginx subrequest/range filter implementations
+
+		rc = ngx_http_vod_range_parse(
+			&ctx->submodule_context.r->headers_in.range->value,
+			response_size,
+			&range_start,
+			&range_end);
+		if (rc != NGX_OK)
+		{
+			ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+				"ngx_http_vod_send_clip_header: failed to parse range header \"%V\"",
+				&ctx->submodule_context.r->headers_in.range->value);
+			return rc;
+		}
+
+		mdat_size = ctx->clipper_parse_result.max_last_offset - ctx->clipper_parse_result.min_first_offset;
+		header_size = response_size - mdat_size;
+
+		if (range_end < header_size)
+		{
+			ctx->clipper_parse_result.max_last_offset = 0;
+		}
+		else if (mdat_size > range_end - header_size)
+		{
+			ctx->clipper_parse_result.max_last_offset = ctx->clipper_parse_result.min_first_offset + range_end - header_size;
+		}
+
+		if (range_start > header_size)
+		{
+			ctx->clipper_parse_result.min_first_offset += range_start - header_size;
+		}
 	}
 
 	return NGX_OK;
@@ -1730,17 +1780,20 @@ ngx_http_vod_run_state_machine(ngx_http_vod_ctx_t *ctx)
 
 		if (ctx->submodule_context.request_params.request == NULL)
 		{
-			ctx->submodule_context.cur_suburi = ctx->submodule_context.request_params.suburis;
-
-			ctx->state = STATE_DUMP_FILE_PART;
-
-			rc = ctx->dump_part(
-				ctx->async_reader_context[ctx->submodule_context.cur_suburi->file_index],
-				ctx->clipper_parse_result.min_first_offset,
-				ctx->clipper_parse_result.max_last_offset);
-			if (rc != NGX_OK)
+			if (ctx->clipper_parse_result.min_first_offset < ctx->clipper_parse_result.max_last_offset)
 			{
-				return rc;
+				ctx->submodule_context.cur_suburi = ctx->submodule_context.request_params.suburis;
+
+				ctx->state = STATE_DUMP_FILE_PART;
+
+				rc = ctx->dump_part(
+					ctx->async_reader_context[ctx->submodule_context.cur_suburi->file_index],
+					ctx->clipper_parse_result.min_first_offset,
+					ctx->clipper_parse_result.max_last_offset);
+				if (rc != NGX_OK)
+				{
+					return rc;
+				}
 			}
 
 			rc = ngx_http_vod_finalize_segment_response(ctx);
@@ -1827,6 +1880,7 @@ static void
 ngx_http_vod_handle_read_completed(void* context, ngx_int_t rc, ssize_t bytes_read)
 {
 	ngx_http_vod_ctx_t *ctx = (ngx_http_vod_ctx_t *)context;
+	ssize_t expected_size;
 
 	if (rc != NGX_OK)
 	{
@@ -1835,7 +1889,19 @@ ngx_http_vod_handle_read_completed(void* context, ngx_int_t rc, ssize_t bytes_re
 		goto finalize_request;
 	}
 
-	if (bytes_read <= 0 && ctx->state != STATE_DUMP_FILE_PART)
+	if (ctx->state == STATE_DUMP_FILE_PART)
+	{
+		expected_size = ctx->clipper_parse_result.max_last_offset - ctx->clipper_parse_result.min_first_offset;
+		if (bytes_read != expected_size)
+		{
+			ngx_log_error(NGX_LOG_ERR, ctx->submodule_context.request_context.log, 0,
+				"ngx_http_vod_handle_read_completed: read size %z different than expected %z, probably a truncated file", 
+				bytes_read, expected_size);
+			rc = ngx_http_vod_status_to_ngx_error(VOD_BAD_DATA);
+			goto finalize_request;
+		}
+	}
+	else if (bytes_read <= 0)
 	{
 		ngx_log_error(NGX_LOG_ERR, ctx->submodule_context.request_context.log, 0,
 			"ngx_http_vod_handle_read_completed: bytes read is zero");
@@ -2022,11 +2088,12 @@ ngx_http_vod_file_open_completed_internal(void* context, ngx_int_t rc, ngx_flag_
 		if (fallback && rc == NGX_HTTP_NOT_FOUND)
 		{
 			// try the fallback
-			if (ngx_http_vod_dump_request_to_fallback(ctx->submodule_context.r) != NGX_DONE)
+			rc = ngx_http_vod_dump_request_to_fallback(ctx->submodule_context.r);
+			if (rc != NGX_DONE)
 			{
-				goto finalize_request;
+				rc = NGX_HTTP_NOT_FOUND;
 			}
-			return;
+			goto finalize_request;
 		}
 
 		ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ctx->submodule_context.r->connection->log, 0,
@@ -2122,10 +2189,14 @@ ngx_http_vod_init_file_reader_internal(ngx_http_request_t *r, ngx_str_t* path, u
 			{
 				return NGX_HTTP_NOT_FOUND;
 			}
+			return rc;
 		}
 
-		ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-			"ngx_http_vod_init_file_reader_internal: ngx_file_reader_init failed %i", rc);
+		if (rc != NGX_AGAIN)
+		{
+			ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+				"ngx_http_vod_init_file_reader_internal: ngx_file_reader_init failed %i", rc);
+		}
 		return rc;
 	}
 
@@ -2205,7 +2276,7 @@ ngx_http_vod_local_request_handler(ngx_http_request_t *r)
 
 ////// Mapped mode only
 
-static void ngx_http_vod_path_request_finished(void* context, ngx_int_t rc, ngx_buf_t* response);
+static void ngx_http_vod_path_request_finished(void* context, ngx_int_t rc, off_t content_length, ngx_buf_t* response);
 
 static ngx_int_t
 ngx_http_vod_run_mapped_mode_state_machine(ngx_http_request_t *r)
@@ -2314,7 +2385,7 @@ ngx_http_vod_run_mapped_mode_state_machine(ngx_http_request_t *r)
 }
 
 static void 
-ngx_http_vod_path_request_finished(void* context, ngx_int_t rc, ngx_buf_t* response)
+ngx_http_vod_path_request_finished(void* context, ngx_int_t rc, off_t content_length, ngx_buf_t* response)
 {
 	ngx_http_vod_loc_conf_t *conf;
 	ngx_http_vod_ctx_t *ctx;
@@ -2337,7 +2408,7 @@ ngx_http_vod_path_request_finished(void* context, ngx_int_t rc, ngx_buf_t* respo
 	ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_path_request_finished: result %s", response->pos);
 
 	path.data = response->pos;
-	path.len = response->last - path.data;
+	path.len = content_length;
 
 	if (path.len == 0)
 	{
@@ -2374,9 +2445,8 @@ ngx_http_vod_path_request_finished(void* context, ngx_int_t rc, ngx_buf_t* respo
 		if (rc != NGX_DONE)
 		{
 			rc = NGX_HTTP_NOT_FOUND;
-			goto finalize_request;
 		}
-		return;
+		goto finalize_request;
 	}
 
 	// save to cache
@@ -2441,7 +2511,7 @@ ngx_http_vod_mapped_request_handler(ngx_http_request_t *r)
 ////// Remote mode only
 
 static void
-ngx_http_vod_http_read_completed(void* context, ngx_int_t rc, ngx_buf_t* response)
+ngx_http_vod_http_read_completed(void* context, ngx_int_t rc, off_t content_length, ngx_buf_t* response)
 {
 	ngx_http_vod_ctx_t *ctx = (ngx_http_vod_ctx_t *)context;
 
@@ -2453,7 +2523,7 @@ ngx_http_vod_http_read_completed(void* context, ngx_int_t rc, ngx_buf_t* respons
 		return;
 	}
 
-	ngx_http_vod_handle_read_completed(context, NGX_OK, response->last - response->pos);
+	ngx_http_vod_handle_read_completed(context, NGX_OK, content_length);
 }
 
 static ngx_int_t

--- a/ngx_http_vod_utils.h
+++ b/ngx_http_vod_utils.h
@@ -28,4 +28,10 @@ ngx_int_t ngx_http_vod_merge_string_parts(
 	uint32_t part_count,
 	ngx_str_t* result);
 
+ngx_int_t ngx_http_vod_range_parse(
+	ngx_str_t* range, 
+	off_t content_length, 
+	off_t* out_start, 
+	off_t* out_end);
+
 #endif // _NGX_HTTP_VOD_UTILS_H_INCLUDED_

--- a/test/clip_compare.py
+++ b/test/clip_compare.py
@@ -3,7 +3,8 @@ import urllib2
 import socket
 import time
 
-# note: run with moov cache enabled and moov cache disabled
+# note: run once with moov cache enabled and once with moov cache disabled
+# 	it's recommended to disable debug logs since this test generates a lot of log lines
 
 '''
 nginx.conf

--- a/test/main.py
+++ b/test/main.py
@@ -632,7 +632,7 @@ class BasicTestSuite(TestSuite):
                     expectedResponse = fullResponse[startOffset:]
                     rangeHeader = '%s-' % startOffset
                 elif rangeType == 1:    # suffix (-123)
-                    startOffset = random.randint(0, len(fullResponse) - 1)
+                    startOffset = random.randint(0, len(fullResponse) - 1) + 1
                     expectedResponse = fullResponse[-startOffset:]
                     rangeHeader = '-%s' % startOffset
                 else:                   # regular range (100-200)

--- a/test/nginx.conf
+++ b/test/nginx.conf
@@ -66,6 +66,11 @@ http {
     upstream kalapi {
 		server localhost:80;
     }
+	
+    upstream self {
+        server localhost:8001;
+        keepalive 32;
+    }	
 
     upstream testapi {
 		server localhost:8002;
@@ -83,6 +88,15 @@ http {
         listen       8001 backlog=1024;
         server_name  localhost;
 
+		# location for testing keep-alive - any requests to /self/xxx get proxied to xxx with keepalive
+		# the tested module "sees" keepalive connections even though the test code is not using keepalive
+        location /self/ {
+                proxy_pass http://self/;
+                proxy_http_version 1.1;
+                proxy_set_header Connection "";
+                proxy_set_header Host $http_host;
+        }
+		
 		# internal location for vod subrequests
 		location /__child_request__/ {
 			internal;

--- a/test/test_coverage.py
+++ b/test/test_coverage.py
@@ -64,6 +64,6 @@ for logPrefix, logMessage in logMessages:
     if not foundPrefixes.has_key(logPrefix):
         print '\t' + logMessage
 
-print 'convered:'
+print 'covered:'
 for curLine in foundPrefixes.values():
     print '\t' + curLine[:140]

--- a/test/verify_test_entries.py
+++ b/test/verify_test_entries.py
@@ -3,8 +3,10 @@ import httplib
 import sys
 import os
 
+# Note: need to disable the moov atom cache and the response cache when running the tests
+
 NGINX_LOG_PATH = '/var/log/nginx/error.log'
-BASE_URL = 'http://localhost:8001/mapped/hls'
+BASE_URL = 'http://localhost:8001/mapped'
 
 ### Log tracker - used to verify certain lines appear in nginx log
 class LogTracker:
@@ -30,7 +32,10 @@ for curLine in sys.stdin:
     curLine = curLine.strip()
     if len(curLine) == 0:
         break
-    refId, uri, expectedStatusCode, message = curLine.split(' ', 3)
+    splittedLine = curLine.split(' ', 3)
+    if len(splittedLine) < 4:
+        continue
+    refId, uri, expectedStatusCode, message = splittedLine
     print 'testing %s %s' % (refId, uri)
     logTracker = LogTracker()
     try:

--- a/vod/mp4/mp4_clipper.c
+++ b/vod/mp4/mp4_clipper.c
@@ -885,12 +885,16 @@ mp4_clipper_stsc_clip_data(
 	}
 
 	// init the iterator
-	mp4_parser_stsc_iterator_init(
+	rc = mp4_parser_stsc_iterator_init(
 		&iterator,
 		context->request_context,
 		(stsc_entry_t*)(atom_info->ptr + sizeof(stsc_atom_t)),
 		entries, 
 		context->chunks);
+	if (rc != VOD_OK)
+	{
+		return rc;
+	}
 
 	// jump to the first frame
 	rc = mp4_parser_stsc_iterator(&iterator, context->first_frame, &target_chunk, &sample_count, &next_chunk, &prev_samples);

--- a/vod/mp4/mp4_parser.c
+++ b/vod/mp4/mp4_parser.c
@@ -257,7 +257,7 @@ mp4_parser_parse_mdhd_atom(atom_info_t* atom_info, metadata_parse_context_t* con
 	if (context->media_info.timescale == 0)
 	{
 		vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-			"mp4_parser_parse_mdhd_atom: time scale is zero");
+			"mp4_parser_parse_mdhd_atom: timescale is zero");
 		return VOD_BAD_DATA;
 	}
 


### PR DESCRIPTION
1. set u->length when dumping file part so that upstream will close the request once all the data is received
2. verify all data was received in dump file part requests (both local and remote)
3. when performing mp4 clipping in remote mode need to apply the requested range to the upstream request
4. must call ngx_http_finalize_request when getting NGX_DONE
5. update tests
