### PR TITLE
Bug fixes

### DIFF
--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -1614,7 +1614,8 @@ ngx_http_vod_state_machine_filter_audio(ngx_http_vod_ctx_t *ctx)
 		ctx->cur_stream++)
 	{
 		if (ctx->cur_stream->media_info.media_type != MEDIA_TYPE_AUDIO ||
-			ctx->cur_stream->media_info.speed_nom == ctx->cur_stream->media_info.speed_denom)
+			ctx->cur_stream->media_info.speed_nom == ctx->cur_stream->media_info.speed_denom ||
+			ctx->cur_stream->frame_count == 0)
 		{
 			continue;
 		}

--- a/vod/hds/hds_fragment.c
+++ b/vod/hds/hds_fragment.c
@@ -363,7 +363,7 @@ hds_calculate_output_offsets_and_write_afra_entries(
 		}
 
 		// video key frames start with the codec info
-		if (selected_stream->media_type == MEDIA_TYPE_VIDEO && selected_stream->cur_frame->key_frame)
+		if (selected_stream->cur_frame->key_frame && selected_stream->media_type == MEDIA_TYPE_VIDEO && p != NULL)
 		{
 			p = hds_write_afra_atom_entry(p, 
 				rescale_time(selected_stream->next_frame_dts, selected_stream->timescale, HDS_TIMESCALE),
@@ -587,7 +587,7 @@ hds_muxer_init_fragment(
 	// get the fragment header size
 	if (conf->generate_moof_atom)
 	{
-		afra_atom_size = ATOM_HEADER_SIZE + sizeof(afra_atom_t)+sizeof(afra_entry_t)* mpeg_metadata->video_key_frame_count;
+		afra_atom_size = ATOM_HEADER_SIZE + sizeof(afra_atom_t) + sizeof(afra_entry_t) * mpeg_metadata->video_key_frame_count;
 	}
 	else
 	{
@@ -676,6 +676,11 @@ hds_muxer_init_fragment(
 				break;
 			}
 		}
+	}
+	else
+	{
+		// calculate the output offsets
+		hds_calculate_output_offsets_and_write_afra_entries(state, 0, 0, NULL);
 	}
 
 	// mdat


### PR DESCRIPTION
- ignore clipTo offset if larger than frame count
- calculate the output offset if generate_moof_atom is off
- skip audio filtering if there are no audio frames
