### PR TITLE
prevent crash when there are no tracks

### DIFF
--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -772,6 +772,12 @@ ngx_http_vod_parse_moov_atom(ngx_http_vod_ctx_t *ctx, u_char* moov_buffer, size_
 		return ngx_http_vod_status_to_ngx_error(rc);
 	}
 
+	if (mp4_base_metadata.tracks.nelts == 0)
+	{
+		ngx_memzero(&cur_source->track_array, sizeof(cur_source->track_array));
+		return VOD_OK;
+	}
+
 	if (request->request_class != REQUEST_CLASS_SEGMENT)
 	{
 		request_context->simulation_only = TRUE;

--- a/test/main.py
+++ b/test/main.py
@@ -750,11 +750,11 @@ class BasicTestSuite(TestSuite):
 
     def testBadClipTo(self):
         assertRequestFails(self.getUrl(HLS_PREFIX, '/clipTo/abcd' + HLS_PLAYLIST_FILE), 400)
-        self.logTracker.assertContains('clipTo parser failed')
+        self.logTracker.assertContains('clip to parser failed')
 
     def testBadClipFrom(self):
         assertRequestFails(self.getUrl(HLS_PREFIX, '/clipFrom/abcd' + HLS_PLAYLIST_FILE), 400)
-        self.logTracker.assertContains('clipFrom parser failed')
+        self.logTracker.assertContains('clip from parser failed')
         
 class UpstreamTestSuite(TestSuite):
     def __init__(self, baseUrl, urlFile, serverPort):

--- a/vod/filters/audio_filter.c
+++ b/vod/filters/audio_filter.c
@@ -1358,12 +1358,14 @@ audio_filter_process_init(vod_log_t* log)
 {
 }
 
-vod_status_t 
+vod_status_t
 audio_filter_alloc_state(
 	request_context_t* request_context,
 	read_cache_state_t* read_cache_state,
+	media_sequence_t* sequence,
 	media_clip_t* clip,
 	media_track_t* output_track,
+	size_t* cache_buffer_count,
 	void** result)
 {
 	vod_log_error(VOD_LOG_ERR, request_context->log, 0,


### PR DESCRIPTION
- timescale will be zero in this case and it would crash on the rescale of the duration
- fix compilation when libavcodec is missing