### PR TITLE
add support for controlling dash profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ without the overhead of short segments for the whole duration of the video
 
 * Clipping of MP4 files for progressive download playback
 
-* DASH: common encryption (cenc) support
+* Decryption of CENC-encrypted MP4 files (it is possible to create such files with MP4Box)
+
+* DASH: common encryption (CENC) support
+
+* MSS: PlayReady encryption support
 
 * HLS: Mux audio and video streams from separate MP4 files (HLS/HDS)
 
@@ -339,6 +343,8 @@ Optional fields:
 	which means the first video track and the first audio track
 * `clipFrom` - an integer that specifies an offset in milliseconds, from the beginning of the 
 	media file, from which to start loading frames
+* `encryptionKey` - a base64 encoded string containing the key (128 bit) that should be used
+	to decrypt the media file. 
 	
 #### Rate filter clip
 
@@ -850,6 +856,13 @@ When enabled the server returns absolute URLs in MPD requests
 * **context**: `http`, `server`, `location`
 
 The name of the MPD file (an mpd extension is implied).
+
+#### vod_dash_profiles
+* **syntax**: `vod_dash_profiles profiles`
+* **default**: `urn:mpeg:dash:profile:isoff-main:2011`
+* **context**: `http`, `server`, `location`
+
+Sets the profiles that are returned in the MPD tag in manifest responses.
 
 #### vod_dash_init_file_name_prefix
 * **syntax**: `vod_dash_init_file_name_prefix name`

--- a/ngx_http_vod_dash.c
+++ b/ngx_http_vod_dash.c
@@ -287,6 +287,7 @@ ngx_http_vod_dash_merge_loc_conf(
 	ngx_conf_merge_value(conf->absolute_manifest_urls, prev->absolute_manifest_urls, 1);
 
 	ngx_conf_merge_str_value(conf->manifest_file_name_prefix, prev->manifest_file_name_prefix, "manifest");
+	ngx_conf_merge_str_value(conf->mpd_config.profiles, prev->mpd_config.profiles, "urn:mpeg:dash:profile:isoff-main:2011");
 	ngx_conf_merge_str_value(conf->mpd_config.init_file_name_prefix, prev->mpd_config.init_file_name_prefix, "init");
 	ngx_conf_merge_str_value(conf->mpd_config.fragment_file_name_prefix, prev->mpd_config.fragment_file_name_prefix, "fragment");
 	ngx_conf_merge_uint_value(conf->mpd_config.manifest_format, prev->mpd_config.manifest_format, FORMAT_SEGMENT_TIMELINE);

--- a/ngx_http_vod_dash_commands.h
+++ b/ngx_http_vod_dash_commands.h
@@ -14,6 +14,13 @@
 	BASE_OFFSET + offsetof(ngx_http_vod_dash_loc_conf_t, manifest_file_name_prefix),
 	NULL },
 
+	{ ngx_string("vod_dash_profiles"),
+	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+	ngx_conf_set_str_slot,
+	NGX_HTTP_LOC_CONF_OFFSET,
+	BASE_OFFSET + offsetof(ngx_http_vod_dash_loc_conf_t, mpd_config.profiles),
+	NULL },
+
 	{ ngx_string("vod_dash_init_file_name_prefix"),
 	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
 	ngx_conf_set_str_slot,

--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -14,7 +14,7 @@
 	"    type=\"static\"\n"														\
 	"    mediaPresentationDuration=\"PT%uD.%03uDS\"\n"							\
 	"    minBufferTime=\"PT%uDS\"\n"											\
-	"    profiles=\"urn:mpeg:dash:profile:isoff-main:2011\">\n"
+	"    profiles=\"%V\">\n"
 
 #define VOD_DASH_MANIFEST_PERIOD_HEADER											\
 	"  <Period>\n"
@@ -949,7 +949,7 @@ dash_packager_build_mpd(
 		representation_tags_size;
 
 	result_size =
-		sizeof(VOD_DASH_MANIFEST_HEADER) - 1 + 3 * VOD_INT32_LEN +
+		sizeof(VOD_DASH_MANIFEST_HEADER) - 1 + 3 * VOD_INT32_LEN + conf->profiles.len +
 			base_period_size * period_count +
 		sizeof(VOD_DASH_MANIFEST_FOOTER);
 
@@ -1010,7 +1010,8 @@ dash_packager_build_mpd(
 		VOD_DASH_MANIFEST_HEADER,
 		(uint32_t)(media_set->total_duration / 1000),
 		(uint32_t)(media_set->total_duration % 1000),
-		(uint32_t)(segmenter_conf->max_segment_duration / 1000));
+		(uint32_t)(segmenter_conf->max_segment_duration / 1000), 
+		&conf->profiles);
 
 	cur_duration_items[MEDIA_TYPE_VIDEO] = segment_durations[MEDIA_TYPE_VIDEO].items;
 	cur_duration_items[MEDIA_TYPE_AUDIO] = segment_durations[MEDIA_TYPE_AUDIO].items;

--- a/vod/dash/dash_packager.h
+++ b/vod/dash/dash_packager.h
@@ -26,6 +26,7 @@ typedef struct {
 } atom_writer_t;
 
 typedef struct {
+	vod_str_t profiles;
 	vod_str_t init_file_name_prefix;
 	vod_str_t fragment_file_name_prefix;
 	vod_uint_t manifest_format;


### PR DESCRIPTION
the sample PlayReady C# app played only when profiles had
urn:mpeg:dash:profile:isoff-live:2011.