### PR TITLE
- remove faac and fdk fetching as we no longer rely on them for AAC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ before_install:
     - sudo apt-get install -y libssl-dev libpcre3-dev wget unzip libopencore-amrwb0 libopencore-amrnb0 libass4 libgsm1 libmp3lame0 libopenjpeg2 libschroedinger-1.0-0 libspeex1 libtheora0  libva1  libvpx1 libxvidcore4
     - sudo wget http://installrepo.origin.kaltura.org/repo/releases/kaltura-ffmpeg_amd64.deb
     - sudo wget http://installrepo.kaltura.org/releases/kaltura-ffmpeg-deb-deps/libx264-123_0.123.2189+git35cf912-1_amd64.deb
+    - sudo wget http://installrepo.kaltura.org/releases/kaltura-ffmpeg-deb-deps/libvdpau1_0.4.1-3ubuntu1.2_amd64.deb
     - sudo dpkg -i libx264-123_0.123.2189+git35cf912-1_amd64.deb
-    - sudo wget http://installrepo.kaltura.org/releases/kaltura-ffmpeg-deb-deps/libfdk-aac0_0.1.3-1_amd64.deb
-    - sudo dpkg -i libfdk-aac0_0.1.3-1_amd64.deb
+    - sudo dpkg -i libvdpau1_0.4.1-3ubuntu1.2_amd64.deb
     - sudo dpkg -i kaltura-ffmpeg_amd64.deb
 language: c
 compiler:


### PR DESCRIPTION
- download and install libvdpau1 deb since it cannot be found in the
repos the Travis machines use anymore.