### PR TITLE
use standard nginx upstreams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Change log
+
+Note: the list of changes below may not include all changes, it will include mostly "breaking" changes.
+	Usually, these are changes that require some update to nginx.conf in order to retain the existing behavior.
+
+## 2015/12/15 - removed the upstream module implementation
+	
+nginx-vod is now built to make use of standard nginx upstream modules (e.g. proxy)
+The following configuration settings were removed:
+* vod_child_request - use proxy_pass instead
+* vod_child_request_path - replaced by vod_xxx_upstream_location
+* vod_upstream_host_header - use proxy_set_header instead
+* vod_upstream - replaced by vod_upstream_location
+* vod_connect_timeout - use proxy_connect_timeout
+* vod_send_timeout - use proxy_send_timeout
+* vod_read_timeout - use proxy_read_timeout
+* vod_fallback_upstream - replaced by vod_fallback_upstream_location
+* vod_fallback_connect_timeout - use proxy_connect_timeout
+* vod_fallback_send_timeout - use proxy_send_timeout
+* vod_fallback_read_timeout - use proxy_read_timeout
+* vod_drm_upstream - replaced by vod_drm_upstream_location
+* vod_drm_connect_timeout - use proxy_connect_timeout
+* vod_drm_send_timeout - use proxy_send_timeout
+* vod_drm_read_timeout - use proxy_read_timeout
+
+## 2015/12/06 - added support for MP4 edit lists
+
+nginx-vod now respects edit lists (elst MP4 atom), this can change the set of frames returned in media segments,
+and cause errors in case of a live upgrade. To retain the previous behavior, set vod_ignore_edit_list to on.

--- a/README.md
+++ b/README.md
@@ -378,9 +378,9 @@ A more scalable architecture would be to use proxy servers or a CDN in order to 
 
 In order to perform the encryption, this module needs several parameters, including key & key_id, these parameters
 are fetched from an external server via HTTP GET request.
-The hostname of that server is configured using the vod_drm_upstream parameter, and the request uri is configured 
-using vod_drm_request_uri (this parameter can include nginx variables). 
-The response of that server is a JSON, with the following format:
+The vod_drm_upstream_location parameter specifies an nginx location that is used to access the DRM server,
+and the request uri is configured using vod_drm_request_uri (this parameter can include nginx variables). 
+The response of the DRM server is a JSON, with the following format:
 
 `[{"pssh": [{"data": "CAESEGMyZjg2MTczN2NjNGYzODIaB2thbHR1cmEiCjBfbmptaWlwbXAqBVNEX0hE", "uuid": "edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"}], "key": "GzoNU9Dfwc//Iq3/zbzMUw==", "key_id": "YzJmODYxNzM3Y2M0ZjM4Mg=="}]`
 
@@ -599,35 +599,19 @@ Sets the size of the cache buffers used when reading MP4 frames.
 
 When enabled, the module ignores any edit lists (elst) in the MP4 file.
 
-#### vod_child_request
-* **syntax**: `vod_child_request`
-* **default**: `n/a`
-* **context**: `location`
-
-Configures the enclosing location as handling nginx-vod module child requests (remote/mapped modes only)
-There should be at least one location with this command when working in remote/mapped modes.
-Note that multiple vod locations can point to a single location having vod_child_request.
-
-#### vod_child_request_path
-* **syntax**: `vod_child_request_path path`
-* **default**: `none`
-* **context**: `location`
-
-Sets the path of an internal location that has vod_child_request enabled (remote/mapped modes only)
-
-#### vod_upstream
-* **syntax**: `vod_upstream upstream_name`
+#### vod_upstream_location
+* **syntax**: `vod_upstream_location location`
 * **default**: `none`
 * **context**: `http`, `server`, `location`
 
-Sets the upstream that should be used for reading the MP4 file (remote mode) or mapping the request URI (mapped mode).
+Sets an nginx location that is used to read the MP4 file (remote mode) or mapping the request URI (mapped mode).
 
-#### vod_upstream_host_header
-* **syntax**: `vod_upstream_host_header host_name`
-* **default**: `the host name of original request`
+#### vod_max_upstream_headers_size
+* **syntax**: `vod_max_upstream_headers_size size`
+* **default**: `4k`
 * **context**: `http`, `server`, `location`
 
-Sets the value of the HTTP host header that should be sent to the upstream (remote/mapped modes only).
+Sets the size that is allocated for holding the response headers when issuing upstream requests (to vod_xxx_upstream_location).
 
 #### vod_upstream_extra_args
 * **syntax**: `vod_upstream_extra_args "arg1=value1&arg2=value2&..."`
@@ -636,27 +620,6 @@ Sets the value of the HTTP host header that should be sent to the upstream (remo
 
 Extra query string arguments that should be added to the upstream request (remote/mapped modes only).
 The parameter value can contain variables.
-
-#### vod_connect_timeout
-* **syntax**: `vod_connect_timeout timeout`
-* **default**: `60s`
-* **context**: `http`, `server`, `location`
-
-Sets the timeout in milliseconds for connecting to the upstream (remote/mapped modes only).
-
-#### vod_send_timeout
-* **syntax**: `vod_send_timeout timeout`
-* **default**: `60s`
-* **context**: `http`, `server`, `location`
-
-Sets the timeout in milliseconds for sending data to the upstream (remote/mapped modes only).
-
-#### vod_read_timeout
-* **syntax**: `vod_read_timeout timeout`
-* **default**: `60s`
-* **context**: `http`, `server`, `location`
-
-Sets the timeout in milliseconds for reading data from the upstream (remote/mapped modes only).
 
 #### vod_path_mapping_cache
 * **syntax**: `vod_path_mapping_cache zone_name zone_size`
@@ -686,33 +649,12 @@ Sets the postfix that is expected in URI mapping responses (mapped mode only).
 
 Sets the maximum length of a path returned from upstream (mapped mode only).
 
-#### vod_fallback_upstream
-* **syntax**: `vod_fallback_upstream upstream_name`
+#### vod_fallback_upstream_location
+* **syntax**: `vod_fallback_upstream_location location`
 * **default**: `none`
 * **context**: `http`, `server`, `location`
 
-Sets an upstream to forward the request to when encountering a file not found error (local/mapped modes only).
-
-#### vod_fallback_connect_timeout
-* **syntax**: `vod_fallback_connect_timeout timeout`
-* **default**: `60s`
-* **context**: `http`, `server`, `location`
-
-Sets the timeout in milliseconds for connecting to the fallback upstream (local/mapped modes only).
-
-#### vod_fallback_send_timeout
-* **syntax**: `vod_fallback_send_timeout timeout`
-* **default**: `60s`
-* **context**: `http`, `server`, `location`
-
-Sets the timeout in milliseconds for sending data to the fallback upstream (local/mapped modes only).
-
-#### vod_fallback_read_timeout
-* **syntax**: `vod_fallback_read_timeout timeout`
-* **default**: `60s`
-* **context**: `http`, `server`, `location`
-
-Sets the timeout in milliseconds for reading data from the fallback upstream (local/mapped modes only).
+Sets an nginx location to which the request is forwarded after encountering a file not found error (local/mapped modes only).
 
 #### vod_proxy_header_name
 * **syntax**: `vod_proxy_header_name name`
@@ -805,33 +747,12 @@ Sets the number of clear (unencrypted) segments in the beginning of the stream. 
 
 Sets the maximum length of a drm info returned from upstream.
 
-#### vod_drm_upstream
-* **syntax**: `vod_drm_upstream upstream_name`
+#### vod_drm_upstream_location
+* **syntax**: `vod_drm_upstream_location location`
 * **default**: `none`
 * **context**: `http`, `server`, `location`
 
-Sets the upstream that should be used for getting the DRM info for the file.
-
-#### vod_drm_connect_timeout
-* **syntax**: `vod_drm_connect_timeout timeout`
-* **default**: `60s`
-* **context**: `http`, `server`, `location`
-
-Sets the timeout in milliseconds for connecting to the upstream.
-
-#### vod_drm_send_timeout
-* **syntax**: `vod_drm_send_timeout timeout`
-* **default**: `60s`
-* **context**: `http`, `server`, `location`
-
-Sets the timeout in milliseconds for sending data to the upstream.
-
-#### vod_drm_read_timeout
-* **syntax**: `vod_drm_read_timeout timeout`
-* **default**: `60s`
-* **context**: `http`, `server`, `location`
-
-Sets the timeout in milliseconds for reading data from the upstream.
+Sets the nginx location that should be used for getting the DRM info for the file.
 
 #### vod_drm_info_cache
 * **syntax**: `vod_drm_info_cache zone_name zone_size`
@@ -1026,34 +947,49 @@ Note: Configuration directives that can accept variables are explicitly marked a
 
 	http {
 		upstream fallback {
-			server kalhls-a-pa.origin.kaltura.com:80;
+			server fallback.kaltura.com:80;
 		}
 
-		server {		
+		server {
+			# vod settings
+			vod_mode local;
+			vod_fallback_upstream_location /fallback;
+			vod_last_modified 'Sun, 19 Nov 2000 08:52:00 GMT';
+			vod_last_modified_types *;
+
+			# vod caches
+			vod_moov_cache moov_cache 512m;
+			vod_response_cache response_cache 128m;
+			
+			# gzip manifests
+			gzip on;
+			gzip_types application/vnd.apple.mpegurl;
+
+			# file handle caching / aio
 			open_file_cache          max=1000 inactive=5m;
 			open_file_cache_valid    2m;
 			open_file_cache_min_uses 1;
 			open_file_cache_errors   on;
-
 			aio on;
+			
+			location ^~ /fallback/ {
+				internal;
+				proxy_pass http://fallback/;
+				proxy_set_header Host $http_host;
+			}
 
 			location /content/ {
+				root /web/;
 				vod hls;
-				vod_mode local;
-				vod_moov_cache moov_cache 512m;
-				vod_fallback_upstream fallback;
-
-				root /web/content;
 				
-				gzip on;
-				gzip_types application/vnd.apple.mpegurl;
-
+				add_header Access-Control-Allow-Headers '*';
+				add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
+				add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';
+				add_header Access-Control-Allow-Origin '*';
 				expires 100d;
-				add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
 			}
 		}
 	}
-
 
 #### Mapped configuration
 
@@ -1063,41 +999,57 @@ Note: Configuration directives that can accept variables are explicitly marked a
 		}
 
 		upstream fallback {
-			server kalhls-a-pa.origin.kaltura.com:80;
+			server fallback.kaltura.com:80;
 		}
 
 		server {
+			# vod settings
+			vod_mode mapped;
+			vod_upstream_location /kalapi;
+			vod_upstream_extra_args "pathOnly=1";
+			vod_fallback_upstream_location /fallback;
+			vod_last_modified 'Sun, 19 Nov 2000 08:52:00 GMT';
+			vod_last_modified_types *;
 
+			# vod caches
+			vod_moov_cache moov_cache 512m;
+			vod_response_cache response_cache 128m;
+			vod_path_mapping_cache mapping_cache 5m;
+			
+			# gzip manifests
+			gzip on;
+			gzip_types application/vnd.apple.mpegurl;
+
+			# file handle caching / aio
 			open_file_cache          max=1000 inactive=5m;
 			open_file_cache_valid    2m;
 			open_file_cache_min_uses 1;
 			open_file_cache_errors   on;
-
 			aio on;
 			
-			location ^~ /__child_request__/ {
+			location ^~ /fallback/ {
 				internal;
-				vod_child_request;
+				proxy_pass http://fallback/;
+				proxy_set_header Host $http_host;
 			}
-		
+
+			location ^~ /kalapi/ {
+				internal;
+				proxy_pass http://kalapi/;
+				proxy_set_header Host $http_host;
+			}
+
 			location ~ ^/p/\d+/(sp/\d+/)?serveFlavor/ {
+				# encrypted hls
 				vod hls;
-				vod_mode mapped;
-				vod_moov_cache moov_cache 512m;
 				vod_secret_key "mukkaukk$vod_filepath";
 				vod_hls_encryption_method aes-128;
-				vod_child_request_path /__child_request__/;
-				vod_upstream kalapi;
-				vod_upstream_host_header www.kaltura.com;
-				vod_upstream_extra_args "pathOnly=1";
-				vod_path_mapping_cache mapping_cache 5m;
-				vod_fallback_upstream fallback;
-
-				gzip on;
-				gzip_types application/vnd.apple.mpegurl;
-
+				
+				add_header Access-Control-Allow-Headers '*';
+				add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
+				add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';
+				add_header Access-Control-Allow-Origin '*';
 				expires 100d;
-				add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
 			}
 		}
 	}
@@ -1109,32 +1061,46 @@ Note: Configuration directives that can accept variables are explicitly marked a
 			server www.kaltura.com:80;
 		}
 
-		server {		
-			location ^~ /__child_request__/ {
+		server {
+			# vod settings
+			vod_mode remote;
+			vod_upstream_location /kalapi;
+			vod_last_modified 'Sun, 19 Nov 2000 08:52:00 GMT';
+			vod_last_modified_types *;
+
+			# vod caches
+			vod_moov_cache moov_cache 512m;
+			vod_response_cache response_cache 128m;
+			
+			# gzip manifests
+			gzip on;
+			gzip_types application/vnd.apple.mpegurl;
+
+			# file handle caching / aio
+			open_file_cache          max=1000 inactive=5m;
+			open_file_cache_valid    2m;
+			open_file_cache_min_uses 1;
+			open_file_cache_errors   on;
+			aio on;
+			
+			location ^~ /kalapi/ {
 				internal;
-				vod_child_request;
+				proxy_pass http://kalapi/;
+				proxy_set_header Host $http_host;
 			}
 
 			location ~ ^/p/\d+/(sp/\d+/)?serveFlavor/ {
 				vod hls;
-				vod_mode remote;
-				vod_moov_cache moov_cache 512m;
-				vod_secret_key "mukkaukk$vod_suburi";
-				vod_hls_encryption_method aes-128;
-				vod_child_request_path /__child_request__/;
-				vod_upstream kalapi;
-				vod_upstream_host_header www.kaltura.com;
-
-				gzip on;
-				gzip_types application/vnd.apple.mpegurl;
-
+				
+				add_header Access-Control-Allow-Headers '*';
+				add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
+				add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';
+				add_header Access-Control-Allow-Origin '*';
 				expires 100d;
-				add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
 			}
 		}
 	}
 
-	
 ### Copyright & License
 
 All code in this project is released under the [AGPLv3 license](http://www.gnu.org/licenses/agpl-3.0.html) unless a different license for a particular library is specified in the applicable library path. 

--- a/conf/kaltura.conf.template
+++ b/conf/kaltura.conf.template
@@ -49,8 +49,7 @@ http {
 
 		# common vod settings
 		vod_mode mapped;
-		vod_child_request_path /__child_request__/;
-		vod_upstream kalapi;
+		vod_upstream_location /kalapi_proxy;
 		vod_upstream_extra_args "pathOnly=1";
 
 		# shared memory zones
@@ -85,9 +84,10 @@ http {
 		}
 		
 		# internal location for vod subrequests
-		location /__child_request__/ {
+		location /kalapi_proxy/ {
 			internal;
-			vod_child_request;
+			proxy_pass http://kalapi/;
+			proxy_set_header Host $http_host;
 		}
 		
 		# serve flavor progressive (clipFrom/To are not supported with 'vod none' so they are proxied)

--- a/config
+++ b/config
@@ -52,7 +52,7 @@ if [ $ngx_found = yes ]; then
     CORE_LIBS="$CORE_LIBS -lavfilter -lavutil"
 fi
 
-HTTP_MODULES="$HTTP_MODULES ngx_http_vod_module"
+HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_vod_module"
 
 NGX_ADDON_DEPS="$NGX_ADDON_DEPS                                     \
                 $ngx_addon_dir/ngx_async_open_file_cache.h          \

--- a/ngx_child_http_request.c
+++ b/ngx_child_http_request.c
@@ -7,763 +7,55 @@
 #include "ngx_child_http_request.h"
 #include "ngx_http_vod_module.h"
 
+// constants
+#define RANGE_FORMAT "bytes=%O-%O"
+
 // macros
-#define is_dump_request(r) (r == r->main)		// regular requests use subrequests
+#define is_in_memory(ctx) (ctx->response_buffer != NULL)
 
 // typedefs
 typedef struct {
-	ngx_buf_t* request_buffer;
-	ngx_http_status_t status;
-} ngx_child_request_base_context_t;		// fields common to dump requests and child requests
-
-typedef struct {
-	ngx_child_request_base_context_t base;		// must be first
 
 	// fixed
-	ngx_http_upstream_conf_t* upstream_conf;
 	ngx_child_request_callback_t callback;
 	void* callback_context;
-	ngx_flag_t in_memory;
 
-	// in memory only
-	u_char* headers_buffer;
-	size_t headers_buffer_size;
-	off_t read_body_size;
-	u_char* response_buffer;
-	off_t response_buffer_size;
+	// deferred init
+	ngx_buf_t* response_buffer;
+	ngx_list_t upstream_headers;
 
 	// temporary completion state
 	ngx_http_upstream_t *upstream;
-	void *original_context;
 	ngx_int_t error_code;
 	ngx_http_event_handler_pt original_write_event_handler;
+	void *original_context;
+
+	// misc
+	ngx_flag_t dont_send_header;
+	ngx_int_t send_header_result;
 
 } ngx_child_request_context_t;
 
-// globals
-static ngx_str_t child_http_hide_headers[] = {
-	ngx_string("Date"),
-	ngx_string("Server"),
-	ngx_null_string
-};
-
 // constants
-static const char content_length_header[] = "content-length";
+static ngx_str_t ngx_http_vod_head_method = { 4, (u_char *) "HEAD " };
 
-static ngx_int_t
-ngx_http_vod_create_request(ngx_http_request_t *r)
-{
-	ngx_chain_t *cl;
-	ngx_child_request_base_context_t* ctx;
+static ngx_str_t range_key = ngx_string("Range");
+static u_char* range_lowcase_key = (u_char*)"range";
+static ngx_uint_t range_hash =
+	ngx_hash(ngx_hash(ngx_hash(ngx_hash('r', 'a'), 'n'), 'g'), 'e');
 
-	ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_create_request: started");
-	
-	// allocate a chain and associate the previously created request buffer
-	cl = ngx_alloc_chain_link(r->pool);
-	if (cl == NULL) 
-	{
-		ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-			"ngx_http_vod_create_request: ngx_alloc_chain_link failed");
-		return NGX_ERROR;
-	}
+static ngx_str_t accept_encoding_key = ngx_string("Accept-Encoding");
+static u_char* accept_encoding_lowcase_key = (u_char*)"accept-encoding";
+static ngx_uint_t accept_encoding_hash =
+	ngx_hash(ngx_hash(ngx_hash(ngx_hash(ngx_hash(ngx_hash(ngx_hash(
+	ngx_hash(ngx_hash(ngx_hash(ngx_hash(ngx_hash(ngx_hash(ngx_hash(
+	'a', 'c'), 'c'), 'e'), 'p'), 't'), '-'), 'e'), 'n'), 'c'), 'o'), 'd'), 'i'), 'n'), 'g');
 
-	ctx = ngx_http_get_module_ctx(r, ngx_http_vod_module);
-	cl->buf = ctx->request_buffer;
-	cl->next = NULL;
-
-	r->upstream->request_bufs = cl;
-
-	ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_create_request: done %s", ctx->request_buffer->pos);
-
-	return NGX_OK;
-}
+// globals
+static ngx_http_output_header_filter_pt ngx_http_next_header_filter;
 
 static void
-ngx_http_vod_finalize_request(ngx_http_request_t *r, ngx_int_t rc)
-{
-	ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_finalize_request: called rc=%i", rc);
-}
-
-static ngx_int_t
-ngx_http_vod_reinit_request(ngx_http_request_t *r)
-{
-	ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_reinit_request: called");
-
-	return NGX_OK;
-}
-
-static ngx_int_t
-ngx_http_vod_process_header(ngx_http_request_t *r)
-{
-	ngx_child_request_context_t* ctx;
-	ngx_http_upstream_t *u;
-	ngx_table_elt_t *h;
-	ngx_int_t rc;
-
-	u = r->upstream;
-
-	// Note: ctx must not be used in case of a dump request
-	ctx = ngx_http_get_module_ctx(r, ngx_http_vod_module);
-
-	for (;;) 
-	{
-		rc = ngx_http_parse_header_line(r, &u->buffer, 1);
-		if (rc == NGX_OK)	// a header line has been parsed successfully
-		{
-			if (is_dump_request(r))
-			{
-				h = ngx_list_push(&r->upstream->headers_in.headers);
-				if (h == NULL) 
-				{
-					ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-						"ngx_http_vod_process_header: ngx_list_push failed");
-					return NGX_ERROR;
-				}
-
-				h->hash = r->header_hash;
-
-				h->key.len = r->header_name_end - r->header_name_start;
-				h->value.len = r->header_end - r->header_start;
-
-				h->key.data = ngx_pnalloc(r->pool, h->key.len + 1 + h->value.len + 1 + h->key.len);
-				if (h->key.data == NULL) 
-				{
-					ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-						"ngx_http_vod_process_header: ngx_pnalloc failed (1)");
-					return NGX_ERROR;
-				}
-
-				h->value.data = h->key.data + h->key.len + 1;
-				h->lowcase_key = h->key.data + h->key.len + 1 + h->value.len + 1;
-
-				ngx_memcpy(h->key.data, r->header_name_start, h->key.len);
-				h->key.data[h->key.len] = '\0';
-				ngx_memcpy(h->value.data, r->header_start, h->value.len);
-				h->value.data[h->value.len] = '\0';
-
-				if (h->key.len == r->lowcase_index) 
-				{
-					ngx_memcpy(h->lowcase_key, r->lowcase_header, h->key.len);
-				}
-				else 
-				{
-					ngx_strlow(h->lowcase_key, h->key.data, h->key.len);
-				}
-			}
-
-			// parse the content length
-			if (r->header_name_end - r->header_name_start == sizeof(content_length_header) - 1 &&
-				ngx_memcmp(r->lowcase_header, content_length_header, sizeof(content_length_header) - 1) == 0)
-			{
-				u->headers_in.content_length_n = ngx_atoof(r->header_start, r->header_end - r->header_start);
-				if (u->headers_in.content_length_n < 0) 
-				{
-					ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-						"ngx_http_vod_process_header: failed to parse content length");
-					return NGX_HTTP_UPSTREAM_INVALID_HEADER;
-				}
-
-				// Note: not validating the content length in case of dump, since we don't load the whole response into memory
-				if (!is_dump_request(r) && ctx->in_memory && u->headers_in.content_length_n > ctx->response_buffer_size)
-				{
-					ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-						"ngx_http_vod_process_header: content length %O exceeds the limit %O", u->headers_in.content_length_n, ctx->response_buffer_size);
-					return NGX_HTTP_UPSTREAM_INVALID_HEADER;
-				}
-
-				ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, 
-					"ngx_http_vod_process_header: parsed content length %O", u->headers_in.content_length_n);
-			}
-
-			continue;
-		}
-
-		if (rc == NGX_HTTP_PARSE_HEADER_DONE)	// finished reading all headers
-		{
-			// in case of ngx_dump_request, no need to do anything
-			if (is_dump_request(r))
-			{
-				return NGX_OK;
-			}
-
-			if (u->state && u->state->status != NGX_HTTP_OK && u->state->status != NGX_HTTP_PARTIAL_CONTENT)
-			{
-				ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-					"ngx_http_vod_process_header: upstream returned a bad status %ui", u->state->status);
-				return NGX_HTTP_UPSTREAM_INVALID_HEADER;
-			}
-
-			if (!ctx->in_memory)
-			{
-				return NGX_OK;
-			}
-
-			// make sure we got some content length
-			if (u->headers_in.content_length_n < 0)
-			{
-				ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-					"ngx_http_vod_process_header: got no content-length header");
-				return NGX_HTTP_UPSTREAM_INVALID_HEADER;
-			}
-
-			// allocate a response buffer if needed
-			if (ctx->response_buffer == NULL)
-			{
-				ctx->response_buffer_size = u->headers_in.content_length_n;
-				ctx->response_buffer = ngx_palloc(r->pool, ctx->response_buffer_size + 1);
-				if (ctx->response_buffer == NULL)
-				{
-					ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-						"ngx_http_vod_process_header: ngx_pnalloc failed (2)");
-					return NGX_ERROR;
-				}
-			}
-
-			// in case we already got some of the response body, copy it to the response buffer
-			ctx->read_body_size = u->buffer.last - u->buffer.pos;
-			if (ctx->read_body_size > ctx->response_buffer_size)
-			{
-				ctx->read_body_size = ctx->response_buffer_size;
-			}
-			ngx_memcpy(ctx->response_buffer, u->buffer.pos, ctx->read_body_size);
-
-			// set the upstream buffer to our response buffer
-			u->buffer.start = ctx->response_buffer;
-			u->buffer.pos = u->buffer.start;
-			u->buffer.last = u->buffer.start + ctx->read_body_size;
-			u->buffer.end = u->buffer.start + ctx->response_buffer_size + 1;
-			u->buffer.temporary = 1;
-
-			return NGX_OK;
-		}
-
-		if (rc == NGX_AGAIN)		// need more data
-		{
-			return NGX_AGAIN;
-		}
-
-		// there was error while a header line parsing
-		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-			"ngx_http_vod_process_header: failed to parse header line rc=%i", rc);
-		return NGX_HTTP_UPSTREAM_INVALID_HEADER;
-	}
-}
-
-static ngx_int_t
-ngx_http_vod_process_status_line(ngx_http_request_t *r)
-{
-	ngx_child_request_base_context_t* ctx;
-	ngx_http_upstream_t *u;
-	size_t len;
-	ngx_int_t rc;
-
-	ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_process_status_line: started");
-
-	u = r->upstream;
-
-	ctx = ngx_http_get_module_ctx(r, ngx_http_vod_module);
-	rc = ngx_http_parse_status_line(r, &u->buffer, &ctx->status);
-	if (rc == NGX_AGAIN) 
-	{
-		return rc;
-	}
-
-	if (rc == NGX_ERROR) 
-	{
-		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-			"ngx_http_vod_process_status_line: failed to parse status line");
-		return NGX_ERROR;
-	}
-
-	if (u->state && u->state->status == 0) 
-	{
-		u->state->status = ctx->status.code;
-	}
-
-	u->headers_in.status_n = ctx->status.code;
-
-	len = ctx->status.end - ctx->status.start;
-	u->headers_in.status_line.len = len;
-
-	u->headers_in.status_line.data = ngx_pnalloc(r->pool, len);
-	if (u->headers_in.status_line.data == NULL) 
-	{
-		ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-			"ngx_http_vod_process_status_line: ngx_pnalloc failed");
-		return NGX_ERROR;
-	}
-
-	ngx_memcpy(u->headers_in.status_line.data, ctx->status.start, len);
-
-	if (ctx->status.http_version < NGX_HTTP_VERSION_11)
-	{
-		u->headers_in.connection_close = 1;
-	}
-
-	// change state to processing the rest of the headers
-	u->process_header = ngx_http_vod_process_header;
-
-	return ngx_http_vod_process_header(r);
-}
-
-static void
-ngx_http_vod_abort_request(ngx_http_request_t *r)
-{
-	ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "ngx_http_vod_abort_request: called");
-	return;
-}
-
-static ngx_int_t
-ngx_http_vod_filter_init(void *data)
-{
-	ngx_child_request_context_t* ctx;
-	ngx_http_request_t *r = data;
-	ngx_http_upstream_t *u;
-
-	u = r->upstream;
-
-	if (u->headers_in.content_length_n + 1 > u->buffer.end - u->buffer.start) 
-	{
-		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-			"ngx_http_vod_filter_init: content length %O exceeds buffer size %O", u->headers_in.content_length_n, (off_t)(u->buffer.end - u->buffer.start));
-		return NGX_ERROR;
-	}
-
-	ctx = ngx_http_get_module_ctx(r, ngx_http_vod_module);
-	u->buffer.last = u->buffer.start + ctx->read_body_size;
-	u->length = u->headers_in.content_length_n;
-
-	return NGX_OK;
-}
-
-static ngx_int_t
-ngx_http_vod_filter(void *data, ssize_t bytes)
-{
-	ngx_http_request_t *r = data;
-	ngx_http_upstream_t *u;
-	ngx_buf_t *b;
-
-	u = r->upstream;
-	b = &u->buffer;
-
-	// only need to update the length and buffer position
-	b->last += bytes;
-	u->length -= bytes;
-
-	return NGX_OK;
-}
-
-static ngx_int_t
-ngx_create_upstream(
-	ngx_http_request_t *r, 
-	ngx_http_upstream_conf_t* conf)
-{
-	ngx_http_upstream_t *u;
-	ngx_int_t rc;
-
-	// create the upstream
-	rc = ngx_http_upstream_create(r);
-	if (rc != NGX_OK)
-	{
-		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-			"ngx_create_upstream: failed to create upstream rc=%i", rc);
-		return NGX_ERROR;
-	}
-
-	// initialize the upstream
-	u = r->upstream;
-
-	ngx_str_set(&u->schema, "kalapi://");
-	u->output.tag = (ngx_buf_tag_t)&ngx_http_vod_module;
-	u->buffer.tag = u->output.tag;
-
-	u->conf = conf;
-
-	u->create_request = ngx_http_vod_create_request;
-	u->reinit_request = ngx_http_vod_reinit_request;
-	u->process_header = ngx_http_vod_process_status_line;
-	u->abort_request = ngx_http_vod_abort_request;
-	u->finalize_request = ngx_http_vod_finalize_request;
-
-	return NGX_OK;
-}
-
-static ngx_flag_t
-ngx_should_proxy_header(ngx_table_elt_t* header, ngx_child_request_params_t* params)
-{
-	if (header->key.len == sizeof("host") - 1 &&
-		ngx_memcmp(header->lowcase_key, "host", sizeof("host") - 1) == 0)
-	{
-		return 0;
-	}
-
-	if (!params->proxy_range &&
-		header->key.len == sizeof("range") - 1 &&
-		ngx_memcmp(header->lowcase_key, "range", sizeof("range") - 1) == 0)
-	{
-		return 0;
-	}
-
-	if (!params->proxy_accept_encoding &&
-		header->key.len == sizeof("accept-encoding") - 1 &&
-		ngx_memcmp(header->lowcase_key, "accept-encoding", sizeof("accept-encoding") - 1) == 0)
-	{
-		return 0;
-	}
-
-	return 1;
-}
-
-static ngx_buf_t*
-ngx_init_request_buffer(
-	ngx_http_request_t *r,
-	ngx_buf_t* request_buffer,
-	ngx_child_request_params_t* params)
-{
-	ngx_http_core_srv_conf_t *cscf;
-	ngx_list_part_t              *part;
-	ngx_table_elt_t              *header;
-	ngx_uint_t                    i;
-	ngx_flag_t range_request = params->range_start < params->range_end;
-	ngx_buf_t *b;
-	uintptr_t escape_chars;
-	size_t len;
-	u_char* p;
-
-	// if the host name is empty, use by default the host name of the incoming request
-	if (params->host_name.len == 0)
-	{
-		if (r->headers_in.host != NULL)
-		{
-			params->host_name = r->headers_in.host->value;
-		}
-		else
-		{
-			cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
-			params->host_name = cscf->server_name;
-		}
-	}
-
-	// calculate the request size
-	if (params->escape_uri)
-	{
-		escape_chars = ngx_escape_uri(NULL, params->base_uri.data, params->base_uri.len, NGX_ESCAPE_URI);
-	}
-	else
-	{
-		escape_chars = 0;
-	}
-
-	len =
-		sizeof("HEAD ") - 1 + params->base_uri.len + 2 * escape_chars + sizeof("?") - 1 + params->extra_args.len + sizeof(" HTTP/1.1" CRLF) - 1 +
-		sizeof("Host: ") - 1 + params->host_name.len + sizeof(CRLF) - 1 +
-		params->extra_headers.len +
-		sizeof(CRLF);
-	if (range_request)
-	{
-		len += sizeof("Range: bytes=") - 1 + NGX_INT64_LEN + sizeof("-") - 1 + NGX_INT64_LEN + sizeof(CRLF) - 1;
-	}
-
-	// add all input headers except host and possibly range
-	part = &r->headers_in.headers.part;
-	header = part->elts;
-
-	for (i = 0; /* void */; i++) {
-
-		if (i >= part->nelts) {
-			if (part->next == NULL) {
-				break;
-			}
-
-			part = part->next;
-			header = part->elts;
-			i = 0;
-		}
-
-		if (!ngx_should_proxy_header(&header[i], params))
-		{
-			continue;
-		}
-
-		len += header[i].key.len + sizeof(": ") - 1
-			+ header[i].value.len + sizeof(CRLF) - 1;
-	}
-
-	// get/allocate the request buffer
-	if (request_buffer != NULL && len <= (size_t)(request_buffer->end - request_buffer->start))
-	{
-		b = request_buffer;
-		b->pos = b->start;
-		p = b->start;
-	}
-	else
-	{
-		b = ngx_create_temp_buf(r->pool, len);
-		if (b == NULL)
-		{
-			ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-				"ngx_init_request_buffer: ngx_create_temp_buf failed");
-			return NULL;
-		}
-		p = b->last;
-	}
-
-	// first header line
-	if (params->method == NGX_HTTP_HEAD)
-	{
-		*p++ = 'H';		*p++ = 'E';		*p++ = 'A';		*p++ = 'D';
-	}
-	else
-	{
-		*p++ = 'G';		*p++ = 'E';		*p++ = 'T';
-	}
-	*p++ = ' ';
-
-	if (escape_chars > 0)
-	{
-		p = (u_char *)ngx_escape_uri(p, params->base_uri.data, params->base_uri.len, NGX_ESCAPE_URI);
-	}
-	else
-	{
-		p = ngx_copy(p, params->base_uri.data, params->base_uri.len);
-	}
-
-	if (params->extra_args.len > 0)
-	{
-		if (ngx_strchr(params->base_uri.data, '?'))
-		{
-			*p++ = '&';
-		}
-		else
-		{
-			*p++ = '?';
-		}
-
-		p = ngx_copy(p, params->extra_args.data, params->extra_args.len);
-	}
-	p = ngx_copy(p, " HTTP/1.1" CRLF, sizeof(" HTTP/1.1" CRLF) - 1);
-
-	// host line
-	p = ngx_copy(p, "Host: ", sizeof("Host: ") - 1);
-	p = ngx_copy(p, params->host_name.data, params->host_name.len);
-	*p++ = CR;	*p++ = LF;
-
-	// range request
-	if (range_request)
-	{
-		p = ngx_sprintf(p, "Range: bytes=%O-%O" CRLF, params->range_start, params->range_end - 1);
-	}
-
-	// additional headers
-	p = ngx_copy(p, params->extra_headers.data, params->extra_headers.len);
-
-	// input headers
-	part = &r->headers_in.headers.part;
-	header = part->elts;
-
-	for (i = 0; /* void */; i++) {
-
-		if (i >= part->nelts) {
-			if (part->next == NULL) {
-				break;
-			}
-
-			part = part->next;
-			header = part->elts;
-			i = 0;
-		}
-
-		if (!ngx_should_proxy_header(&header[i], params))
-		{
-			continue;
-		}
-
-		p = ngx_copy(p, header[i].key.data, header[i].key.len);
-
-		*p++ = ':'; *p++ = ' ';
-
-		p = ngx_copy(p, header[i].value.data, header[i].value.len);
-
-		*p++ = CR; *p++ = LF;
-	}
-
-	// headers end
-	*p++ = CR;	*p++ = LF;
-	*p = '\0';
-	b->last = p;
-
-	return b;
-}
-
-ngx_int_t
-ngx_dump_request(
-	ngx_http_request_t *r,
-	ngx_http_upstream_conf_t* upstream_conf,
-	ngx_child_request_params_t* params)
-{
-	ngx_child_request_base_context_t* ctx;
-	ngx_int_t rc;
-
-	// replace the module context - after calling ngx_dump_request the caller is not allowed to use the context
-	ctx = ngx_pcalloc(r->pool, sizeof(*ctx));
-	if (ctx == NULL)
-	{
-		ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-			"ngx_dump_request: ngx_pcalloc failed");
-		return NGX_ERROR;
-	}
-	ngx_http_set_ctx(r, ctx, ngx_http_vod_module);
-
-	// create an upstream
-	rc = ngx_create_upstream(r, upstream_conf);
-	if (rc != NGX_OK)
-	{
-		ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-			"ngx_dump_request: ngx_create_upstream failed %i", rc);
-		return rc;
-	}
-
-	// build the request
-	ctx->request_buffer = ngx_init_request_buffer(r, NULL, params);
-	if (ctx->request_buffer == NULL)
-	{
-		ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-			"ngx_dump_request: ngx_init_request_buffer failed");
-		return NGX_ERROR;
-	}
-
-#if defined nginx_version && nginx_version >= 8011
-	r->main->count++;
-#endif
-	
-	// start the request
-	ngx_http_upstream_init(r);
-
-	return NGX_DONE;
-}
-
-static ngx_int_t
-ngx_http_vod_upstream_non_buffered_filter_init(void *data)
-{
-	ngx_http_request_t *r = data;
-	ngx_http_upstream_t *u;
-
-	u = r->upstream;
-
-	if (u->headers_in.content_length_n > 0)
-	{
-		u->length = u->headers_in.content_length_n;
-	}
-
-	return NGX_OK;
-}
-
-// Note: this function is a copy of ngx_http_upstream_non_buffered_filter, only reason to have
-//		it here is in order to override input_filter_init to set the response length
-//		(it is not possible to override only input_filter_init)
-static ngx_int_t
-ngx_http_vod_upstream_non_buffered_filter(void *data, ssize_t bytes)
-{
-	ngx_http_request_t  *r = data;
-
-	ngx_buf_t            *b;
-	ngx_chain_t          *cl, **ll;
-	ngx_http_upstream_t  *u;
-
-	u = r->upstream;
-
-	for (cl = u->out_bufs, ll = &u->out_bufs; cl; cl = cl->next) {
-		ll = &cl->next;
-	}
-
-	cl = ngx_chain_get_free_buf(r->pool, &u->free_bufs);
-	if (cl == NULL) {
-		return NGX_ERROR;
-	}
-
-	*ll = cl;
-
-	cl->buf->flush = 1;
-	cl->buf->memory = 1;
-
-	b = &u->buffer;
-
-	cl->buf->pos = b->last;
-	b->last += bytes;
-	cl->buf->last = b->last;
-	cl->buf->tag = u->output.tag;
-
-	if (u->length == -1) {
-		return NGX_OK;
-	}
-
-	u->length -= bytes;
-
-	return NGX_OK;
-}
-
-
-ngx_int_t
-ngx_child_request_internal_handler(ngx_http_request_t *r)
-{
-	ngx_child_request_context_t* ctx;
-	ngx_http_upstream_t *u;
-	ngx_int_t rc;
-
-	// create the upstream
-	ctx = ngx_http_get_module_ctx(r, ngx_http_vod_module);
-	rc = ngx_create_upstream(r, ctx->upstream_conf);
-	if (rc != NGX_OK)
-	{
-		ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-			"ngx_child_request_internal_handler: ngx_create_upstream failed %i", rc);
-		return rc;
-	}
-
-	u = r->upstream;
-
-	if (ctx->in_memory)
-	{
-		// initialize the upstream buffer
-		u->buffer.start = ctx->headers_buffer;
-		u->buffer.pos = u->buffer.start;
-		u->buffer.last = u->buffer.start;
-		u->buffer.end = u->buffer.start + ctx->headers_buffer_size;
-		u->buffer.temporary = 1;
-
-		// create the headers list
-		if (ngx_list_init(&u->headers_in.headers, r->pool, 8, sizeof(ngx_table_elt_t)) != NGX_OK)
-		{
-			ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-				"ngx_child_request_internal_handler: ngx_list_init failed");
-			return NGX_ERROR;
-		}
-
-		// initialize the input filter
-		u->input_filter_init = ngx_http_vod_filter_init;
-		u->input_filter = ngx_http_vod_filter;
-		u->input_filter_ctx = r;
-	}
-	else
-	{
-		// initialize the input filter
-		u->input_filter_init = ngx_http_vod_upstream_non_buffered_filter_init;
-		u->input_filter = ngx_http_vod_upstream_non_buffered_filter;
-		u->input_filter_ctx = r;
-	}
-
-#if defined nginx_version && nginx_version >= 8011
-	r->main->count++;
-#endif
-
-	// start the request
-	ngx_http_upstream_init(r);
-
-	return NGX_DONE;
-}
-
-static void
-ngx_http_vod_wev_handler(ngx_http_request_t *r)
+ngx_child_request_wev_handler(ngx_http_request_t *r)
 {
 	ngx_child_request_context_t* ctx;
 	ngx_http_upstream_t *u;
@@ -786,7 +78,7 @@ ngx_http_vod_wev_handler(ngx_http_request_t *r)
 	if (u == NULL)
 	{
 		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-			"ngx_http_vod_wev_handler: unexpected, upstream is null");
+			"ngx_child_request_wev_handler: unexpected, upstream is null");
 		return;
 	}
 
@@ -808,17 +100,45 @@ ngx_http_vod_wev_handler(ngx_http_request_t *r)
 		}
 	}
 
-	// make sure all data was read
+	// get the final error code
 	rc = ctx->error_code;
-	if (rc == NGX_OK && u->length != 0 && u->length != -1)
+	if (rc == NGX_OK)
 	{
-		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-			"ngx_http_vod_wev_handler: upstream connection was closed with %O bytes left to read", u->length);
+		if (u->headers_in.status_n != NGX_HTTP_OK && u->headers_in.status_n != NGX_HTTP_PARTIAL_CONTENT)
+		{
+			if (u->headers_in.status_n != 0)
+			{
+				ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+					"ngx_child_request_wev_handler: upstream returned a bad status %ui", u->headers_in.status_n);
+			}
+			else
+			{
+				ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+					"ngx_child_request_wev_handler: failed to get upstream status");
+			}
+			rc = NGX_HTTP_BAD_GATEWAY;
+		}
+		else if (u->length != 0 && u->length != -1 && is_in_memory(ctx) && !u->headers_in.chunked)
+		{
+			ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+				"ngx_child_request_wev_handler: upstream connection was closed with %O bytes left to read", u->length);
+			rc = NGX_HTTP_BAD_GATEWAY;
+		}
+	}
+	else if (rc == NGX_ERROR)
+	{
+		ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+			"ngx_child_request_wev_handler: got error -1, changing to 502");
 		rc = NGX_HTTP_BAD_GATEWAY;
 	}
-	
+
+	if (ctx->send_header_result != NGX_OK)
+	{
+		rc = ctx->send_header_result;
+	}
+
 	// get the content length
-	if (ctx->in_memory)
+	if (is_in_memory(ctx))
 	{
 		content_length = u->buffer.last - u->buffer.pos;
 	}
@@ -831,8 +151,25 @@ ngx_http_vod_wev_handler(ngx_http_request_t *r)
 		content_length = 0;
 	}
 
-	// notify the caller
-	ctx->callback(ctx->callback_context, rc, content_length, &u->buffer);
+	if (ctx->callback != NULL)
+	{
+		// notify the caller
+		ctx->callback(ctx->callback_context, rc, &u->buffer, content_length);
+	}
+	else
+	{
+		if (r->header_sent || ctx->dont_send_header)
+		{
+			// flush the buffer and close the request
+			ngx_http_send_special(r, NGX_HTTP_LAST);
+			ngx_http_finalize_request(r, NGX_OK);
+		}
+		else
+		{
+			// finalize the request
+			ngx_http_finalize_request(r, rc);
+		}
+	}
 }
 
 static ngx_int_t
@@ -843,6 +180,9 @@ ngx_child_request_finished_handler(
 {
 	ngx_http_request_t          *pr;
 	ngx_child_request_context_t* ctx;
+
+	ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+		"ngx_child_request_finished_handler: error code %ui", rc);
 
 	// make sure we are not called twice for the same request
 	r->post_subrequest = NULL;
@@ -865,7 +205,7 @@ ngx_child_request_finished_handler(
 	pr = r->parent;
 
 	ctx->original_write_event_handler = pr->write_event_handler;
-	pr->write_event_handler = ngx_http_vod_wev_handler;
+	pr->write_event_handler = ngx_child_request_wev_handler;
 
 	// temporarily replace the parent context
 	ctx->original_context = ngx_http_get_module_ctx(pr, ngx_http_vod_module);
@@ -887,54 +227,196 @@ ngx_child_request_finished_handler(
 	return NGX_OK;
 }
 
-// Note: must not return positive error codes (like NGX_HTTP_INTERNAL_SERVER_ERROR)
+static void
+ngx_child_request_initial_wev_handler(ngx_http_request_t *r)
+{
+	ngx_child_request_context_t* ctx;
+	ngx_http_upstream_t* u;
+	ngx_connection_t    *c;
+
+	c = r->connection;
+
+	// call the default request handler
+	r->write_event_handler = ngx_http_handler;
+	ngx_http_handler(r);
+
+	// if request was destroyed ignore
+	if (c->destroyed)
+	{
+		return;
+	}
+
+	// at this point the upstream should have been allocated by the proxy module
+	u = r->upstream;
+	if (u == NULL)
+	{
+		ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+			"ngx_child_request_initial_wev_handler: upstream is null");
+		return;
+	}
+
+	// initialize the upstream buffer
+	ctx = ngx_http_get_module_ctx(r, ngx_http_vod_module);
+	u->buffer = *ctx->response_buffer;
+
+	// initialize the headers list
+	u->headers_in.headers = ctx->upstream_headers;
+	u->headers_in.headers.last = &u->headers_in.headers.part;
+}
+
+static ngx_int_t
+ngx_child_request_copy_headers(
+	ngx_http_request_t* r,
+	ngx_child_request_params_t* params,
+	ngx_http_headers_in_t* dest,
+	ngx_http_headers_in_t* src)
+{
+	ngx_http_core_main_conf_t  *cmcf;
+	ngx_list_part_t *part;
+	ngx_table_elt_t *output;
+	ngx_table_elt_t *ch;
+	ngx_table_elt_t *h;
+	ngx_uint_t i = 0;
+	ngx_http_header_t *hh;
+	ngx_table_elt_t  **ph;
+	ngx_uint_t count;
+	ngx_int_t rc;
+
+	// get the total header count
+	count = 0;
+	for (part = &src->headers.part; part; part = part->next)
+	{
+		count += part->nelts;
+	}
+
+	// allocate dest array
+	rc = ngx_list_init(&dest->headers, r->pool, count + 2, sizeof(ngx_table_elt_t));
+	if (rc != NGX_OK)
+	{
+		ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+			"ngx_child_request_copy_headers: ngx_list_init failed");
+		return NGX_ERROR;
+	}
+
+	output = dest->headers.last->elts;
+
+	// copy relevant headers
+	cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+	part = &src->headers.part;
+	h = part->elts;
+
+	for (i = 0; /* void */; i++)
+	{
+		if (i >= part->nelts)
+		{
+			if (part->next == NULL)
+			{
+				break;
+			}
+
+			part = part->next;
+			h = part->elts;
+			i = 0;
+		}
+
+		ch = h + i;
+
+		// remove range if needed
+		if (ch->hash == range_hash && !params->proxy_range && params->range_start >= params->range_end &&
+			ch->key.len == range_key.len &&
+			ngx_memcmp(ch->lowcase_key, range_lowcase_key, range_key.len) == 0)
+		{
+			dest->range = NULL;
+			continue;
+		}
+
+		// remove accept encoding if needed
+		if (ch->hash == accept_encoding_hash && !params->proxy_accept_encoding &&
+			ch->key.len == accept_encoding_key.len &&
+			ngx_memcmp(ch->lowcase_key, accept_encoding_lowcase_key, accept_encoding_key.len) == 0)
+		{
+#if (NGX_HTTP_GZIP)
+			dest->accept_encoding = NULL;
+#endif
+			continue;
+		}
+
+		// add the header to the output list
+		*output = *ch;
+
+		// update the header pointer, if exists
+		hh = ngx_hash_find(&cmcf->headers_in_hash, h[i].hash,
+			h[i].lowcase_key, h[i].key.len);
+		if (hh)
+		{
+			ph = (ngx_table_elt_t **)((char *)dest + hh->offset);
+
+			*ph = output;
+		}
+
+		output++;
+	}
+
+	// add the extra header if needed
+	if (params->extra_header.key.len != 0)
+	{
+		*output++ = params->extra_header;
+	}
+
+	// set the range if needed
+	if (params->range_start < params->range_end)
+	{
+		if (dest->range == NULL)
+		{
+			h = output++;
+			h->hash = range_hash;
+			h->key = range_key;
+			h->lowcase_key = range_lowcase_key;
+			dest->range = h;
+		}
+		else
+		{
+			h = dest->range;
+		}
+
+		h->value.data = ngx_pnalloc(r->pool, sizeof(RANGE_FORMAT) + 2 * NGX_OFF_T_LEN);
+		if (h->value.data == NULL)
+		{
+			ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+				"ngx_child_request_copy_headers: ngx_pnalloc failed");
+			return NGX_ERROR;
+		}
+
+		h->value.len = ngx_sprintf(
+			h->value.data,
+			RANGE_FORMAT,
+			params->range_start,
+			params->range_end - 1) - h->value.data;
+		h->value.data[h->value.len] = '\0';
+	}
+
+	// update the element count
+	dest->headers.last->nelts = output - (ngx_table_elt_t*)dest->headers.last->elts;
+
+	return NGX_OK;
+}
+
 ngx_int_t
 ngx_child_request_start(
 	ngx_http_request_t *r,
-	ngx_child_request_buffers_t* buffers, 
 	ngx_child_request_callback_t callback,
 	void* callback_context,
-	ngx_http_upstream_conf_t* upstream_conf,
 	ngx_str_t* internal_location,
 	ngx_child_request_params_t* params,
-	off_t max_response_length,
-	u_char* response_buffer)
+	ngx_buf_t* response_buffer)
 {
 	ngx_child_request_context_t* child_ctx;
 	ngx_http_post_subrequest_t *psr;
 	ngx_http_request_t *sr;
 	ngx_uint_t flags;
-	ngx_str_t args = ngx_null_string;
 	ngx_str_t uri;
 	ngx_int_t rc;
 	u_char* p;
-
-	// initialize the headers buffer
-	if (buffers->headers_buffer == NULL || buffers->headers_buffer_size < upstream_conf->buffer_size)
-	{
-		if (buffers->headers_buffer != NULL)
-		{
-			ngx_pfree(r->pool, buffers->headers_buffer);
-		}
-
-		buffers->headers_buffer_size = upstream_conf->buffer_size;
-		buffers->headers_buffer = ngx_palloc(r->pool, buffers->headers_buffer_size);
-		if (buffers->headers_buffer == NULL)
-		{
-			ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-				"ngx_child_request_start: ngx_palloc failed (1)");
-			return NGX_ERROR;
-		}
-	}
-
-	// initialize the request buffer
-	buffers->request_buffer = ngx_init_request_buffer(r, buffers->request_buffer, params);
-	if (buffers->request_buffer == NULL)
-	{
-		ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-			"ngx_child_request_start: ngx_init_request_buffer failed");
-		return NGX_ERROR;
-	}
 
 	// create the child context
 	child_ctx = ngx_pcalloc(r->pool, sizeof(*child_ctx));
@@ -947,18 +429,10 @@ ngx_child_request_start(
 
 	child_ctx->callback = callback;
 	child_ctx->callback_context = callback_context;
-	child_ctx->response_buffer_size = max_response_length;
 	child_ctx->response_buffer = response_buffer;
-	child_ctx->upstream_conf = upstream_conf;
-	child_ctx->headers_buffer_size = buffers->headers_buffer_size;
-	child_ctx->headers_buffer = buffers->headers_buffer;
-	child_ctx->base.request_buffer = buffers->request_buffer;
-	child_ctx->in_memory = max_response_length != 0;
 
 	// build the subrequest uri
-	// Note: this uri is not important, we could have just used internal_location as is
-	//		but adding the child request uri makes the logs more readable
-	uri.data = ngx_palloc(r->pool, internal_location->len + params->base_uri.len + 1);
+	uri.data = ngx_pnalloc(r->pool, internal_location->len + params->base_uri.len + 1);
 	if (uri.data == NULL)
 	{
 		ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
@@ -972,7 +446,7 @@ ngx_child_request_start(
 
 	// create the subrequest
 	psr = ngx_palloc(r->pool, sizeof(ngx_http_post_subrequest_t));
-	if (psr == NULL) 
+	if (psr == NULL)
 	{
 		ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
 			"ngx_child_request_start: ngx_palloc failed (3)");
@@ -982,8 +456,16 @@ ngx_child_request_start(
 	psr->handler = ngx_child_request_finished_handler;
 	psr->data = r;
 
-	if (child_ctx->in_memory)
+	if (is_in_memory(child_ctx))
 	{
+		if (ngx_list_init(&child_ctx->upstream_headers, r->pool, 8,
+			sizeof(ngx_table_elt_t)) != NGX_OK)
+		{
+			ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+				"ngx_child_request_start: ngx_list_init failed");
+			return NGX_ERROR;
+		}
+
 		flags = NGX_HTTP_SUBREQUEST_WAITED | NGX_HTTP_SUBREQUEST_IN_MEMORY;
 	}
 	else
@@ -991,8 +473,8 @@ ngx_child_request_start(
 		flags = NGX_HTTP_SUBREQUEST_WAITED;
 	}
 
-	rc = ngx_http_subrequest(r, &uri, &args, &sr, psr, flags);
-	if (rc == NGX_ERROR) 
+	rc = ngx_http_subrequest(r, &uri, &params->extra_args, &sr, psr, flags);
+	if (rc == NGX_ERROR)
 	{
 		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
 			"ngx_child_request_start: ngx_http_subrequest failed %i", rc);
@@ -1002,126 +484,74 @@ ngx_child_request_start(
 	// set the context of the subrequest
 	ngx_http_set_ctx(sr, child_ctx, ngx_http_vod_module);
 
+	// change the write_event_handler in order to inject the response buffer into the upstream 
+	//	(this can be done only after the proxy module allocates the upstream)
+	if (is_in_memory(child_ctx))
+	{
+		sr->write_event_handler = ngx_child_request_initial_wev_handler;
+	}
+
+	// Note: ngx_http_subrequest always sets the subrequest method to GET
+	if (params->method == NGX_HTTP_HEAD)
+	{
+		sr->method = NGX_HTTP_HEAD;
+		sr->method_name = ngx_http_vod_head_method;
+	}
+	
+	// build the request headers
+	rc = ngx_child_request_copy_headers(r, params, &sr->headers_in, &r->headers_in);
+	if (rc != NGX_OK)
+	{
+		return rc;
+	}
+
 	ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
 		"ngx_child_request_start: completed successfully sr=%p", sr);
 
 	return NGX_AGAIN;
 }
 
+static ngx_int_t
+ngx_child_request_header_filter(ngx_http_request_t *r)
+{
+	ngx_child_request_context_t* ctx;
+	ngx_http_request_t* pr = r->parent;
+
+	// if the request is not a child of a vod request, ignore
+	if (pr == NULL || pr->header_sent || ngx_http_get_module_ctx(pr, ngx_http_vod_module) == NULL)
+	{
+		return ngx_http_next_header_filter(r);
+	}
+
+	// if the request is not a vod request or it's in memory, ignore
+	ctx = ngx_http_get_module_ctx(r, ngx_http_vod_module);
+	if (ctx == NULL || is_in_memory(ctx))
+	{
+		return ngx_http_next_header_filter(r);
+	}
+
+	if (r->headers_out.status != 0)
+	{
+		// send the parent request headers
+		pr->headers_out = r->headers_out;
+		ctx->send_header_result = ngx_http_send_header(pr);
+	}
+	else
+	{
+		// no status code, this can happen in case the proxy module got an invalid status line
+		//	and assumed it's HTTP/0.9, just don't send any header and close the connection when done
+		ctx->dont_send_header = 1;
+		pr->keepalive = 0;
+	}
+
+	return ngx_http_next_header_filter(r);
+}
+
 void
-ngx_child_request_free_buffers(ngx_pool_t* pool, ngx_child_request_buffers_t* buffers)
+ngx_child_request_init()
 {
-	ngx_pfree(pool, buffers->headers_buffer);
-	buffers->headers_buffer = NULL;
-	ngx_pfree(pool, buffers->request_buffer);
-	buffers->request_buffer = NULL;
-}
-
-void 
-ngx_init_upstream_conf(ngx_http_upstream_conf_t* upstream)
-{
-	upstream->connect_timeout = NGX_CONF_UNSET_MSEC;
-	upstream->send_timeout = NGX_CONF_UNSET_MSEC;
-	upstream->read_timeout = NGX_CONF_UNSET_MSEC;
-
-	upstream->buffer_size = NGX_CONF_UNSET_SIZE;
-
-	upstream->hide_headers = NGX_CONF_UNSET_PTR;
-	upstream->pass_headers = NGX_CONF_UNSET_PTR;
-
-	// hardcoded values
-	upstream->cyclic_temp_file = 0;
-	upstream->buffering = 0;
-	upstream->ignore_client_abort = 0;
-	upstream->send_lowat = 0;
-	upstream->bufs.num = 0;
-	upstream->busy_buffers_size = 0;
-	upstream->max_temp_file_size = 0;
-	upstream->temp_file_write_size = 0;
-	upstream->intercept_errors = 1;
-	upstream->intercept_404 = 1;
-	upstream->pass_request_headers = 0;
-	upstream->pass_request_body = 0;
-}
-
-char *
-ngx_merge_upstream_conf(
-	ngx_conf_t *cf,
-	ngx_http_upstream_conf_t* conf_upstream, 
-	ngx_http_upstream_conf_t* prev_upstream)
-{
-	ngx_hash_init_t hash;
-
-	ngx_conf_merge_msec_value(conf_upstream->connect_timeout,
-		prev_upstream->connect_timeout, 60000);
-
-	ngx_conf_merge_msec_value(conf_upstream->send_timeout,
-		prev_upstream->send_timeout, 60000);
-
-	ngx_conf_merge_msec_value(conf_upstream->read_timeout,
-		prev_upstream->read_timeout, 60000);
-
-	ngx_conf_merge_size_value(conf_upstream->buffer_size,
-		prev_upstream->buffer_size,
-		(size_t)ngx_pagesize);
-
-	ngx_conf_merge_bitmask_value(conf_upstream->next_upstream,
-		prev_upstream->next_upstream,
-		(NGX_CONF_BITMASK_SET
-		| NGX_HTTP_UPSTREAM_FT_ERROR
-		| NGX_HTTP_UPSTREAM_FT_TIMEOUT));
-
-	if (conf_upstream->next_upstream & NGX_HTTP_UPSTREAM_FT_OFF) 
-	{
-		conf_upstream->next_upstream = NGX_CONF_BITMASK_SET | NGX_HTTP_UPSTREAM_FT_OFF;
-	}
-
-	if (conf_upstream->upstream == NULL) 
-	{
-		conf_upstream->upstream = prev_upstream->upstream;
-	}
-
-	hash.max_size = 512;
-	hash.bucket_size = ngx_align(64, ngx_cacheline_size);
-	hash.name = "child_request_headers_hash";
-
-	if (ngx_http_upstream_hide_headers_hash(cf, conf_upstream,
-		prev_upstream, child_http_hide_headers, &hash)
-		!= NGX_OK)
-	{
-		return NGX_CONF_ERROR;
-	}
-
-	return NGX_CONF_OK;
-}
-
-char *
-ngx_http_upstream_command(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
-{
-	ngx_http_upstream_conf_t *upstream_conf = (ngx_http_upstream_conf_t*)((u_char*)conf + cmd->offset);
-	ngx_str_t                       *value;
-	ngx_url_t                        u;
-
-	if (upstream_conf->upstream)
-	{
-		return "is duplicate";
-	}
-
-	value = cf->args->elts;
-
-	ngx_memzero(&u, sizeof(ngx_url_t));
-
-	u.url = value[1];
-	u.no_resolve = 1;
-	u.default_port = 80;
-
-	upstream_conf->upstream = ngx_http_upstream_add(cf, &u, 0);
-	if (upstream_conf->upstream == NULL)
-	{
-		ngx_log_debug0(NGX_LOG_DEBUG_HTTP, cf->log, 0,
-			"ngx_http_upstream_command: ngx_http_upstream_add failed");
-		return NGX_CONF_ERROR;
-	}
-
-	return NGX_CONF_OK;
+	// Note: need to install a header filter in order to support dumping requests -
+	//	the headers of the parent request need to be sent before any body data is written
+	ngx_http_next_header_filter = ngx_http_top_header_filter;
+	ngx_http_top_header_filter = ngx_child_request_header_filter;
 }

--- a/ngx_child_http_request.h
+++ b/ngx_child_http_request.h
@@ -4,98 +4,36 @@
 // includes
 #include <ngx_http.h>
 
-#define DEFINE_UPSTREAM_COMMANDS(member, command_prefix)							\
-	{ ngx_string("vod_" command_prefix "upstream"),									\
-	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,	\
-	ngx_http_upstream_command,														\
-	NGX_HTTP_LOC_CONF_OFFSET,														\
-	offsetof(ngx_http_vod_loc_conf_t, member),										\
-	NULL },																			\
-																					\
-	{ ngx_string("vod_" command_prefix "connect_timeout"),							\
-	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,	\
-	ngx_conf_set_msec_slot,															\
-	NGX_HTTP_LOC_CONF_OFFSET,														\
-	offsetof(ngx_http_vod_loc_conf_t, member.connect_timeout),						\
-	NULL },																			\
-																					\
-	{ ngx_string("vod_" command_prefix "send_timeout"),								\
-	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,	\
-	ngx_conf_set_msec_slot,															\
-	NGX_HTTP_LOC_CONF_OFFSET,														\
-	offsetof(ngx_http_vod_loc_conf_t, member.send_timeout),							\
-	NULL },																			\
-																					\
-	{ ngx_string("vod_" command_prefix "read_timeout"),								\
-	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,	\
-	ngx_conf_set_msec_slot,															\
-	NGX_HTTP_LOC_CONF_OFFSET,														\
-	offsetof(ngx_http_vod_loc_conf_t, member.read_timeout),							\
-	NULL },
-
-
-
-
 // typedefs
-typedef void (*ngx_child_request_callback_t)(void* context, ngx_int_t rc, off_t content_length, ngx_buf_t* response);
+typedef void(*ngx_child_request_callback_t)(void* context, ngx_int_t rc, ngx_buf_t* buf, off_t bytes_read);
 
 typedef struct {
 	ngx_uint_t method;
 	ngx_str_t base_uri;
 	ngx_str_t extra_args;
-	ngx_str_t host_name;
 	off_t range_start;
 	off_t range_end;
-	ngx_str_t extra_headers;
+	ngx_table_elt_t extra_header;
 	ngx_flag_t proxy_range;
 	ngx_flag_t proxy_accept_encoding;
-	ngx_flag_t escape_uri;
 } ngx_child_request_params_t;
 
-// Note: the purpose of this struct is to reuse the request & headers buffers between several 
-//		child requests under the same parent request. it is significant only in remote mode.
-typedef struct {
-	ngx_buf_t* request_buffer;
-	u_char* headers_buffer;
-	size_t headers_buffer_size;
-} ngx_child_request_buffers_t;
+// functions
 
-// request initiation function
-
-// IMPORTANT NOTE: due to the implementation of ngx_http_upstream_process_body_in_memory, and in order to
-//		avoid memory copy operations, this function assumes that the buffer passed to it has a size of 
-//		at least max_response_length + 1 (unlike max_response_length like one would expect)
-//		this issue is discussed in http://trac.nginx.org/nginx/ticket/680
-
+// Notes:
+//	1. callback is optional, if it is not supplied, the module will finalize the request
+//		when the upstream request completes.
+//	2. response_buffer is optional, if it is not supplied, the upstream response gets written
+//		to the parent request. when a response buffer is supplied, the response is written to it, 
+//		the buffer should be large enough to contain both the response body and the response headers.
 ngx_int_t ngx_child_request_start(
 	ngx_http_request_t *r,
-	ngx_child_request_buffers_t* buffers,
 	ngx_child_request_callback_t callback,
 	void* callback_context,
-	ngx_http_upstream_conf_t* upstream_conf,
 	ngx_str_t* internal_location,
 	ngx_child_request_params_t* params,
-	off_t max_response_length,
-	u_char* response_buffer);
+	ngx_buf_t* response_buffer);
 
-ngx_int_t ngx_dump_request(
-	ngx_http_request_t *r,
-	ngx_http_upstream_conf_t* upstream_conf,
-	ngx_child_request_params_t* params);
-
-// free function
-void ngx_child_request_free_buffers(ngx_pool_t* pool, ngx_child_request_buffers_t* buffers);
-
-// config functions
-void ngx_init_upstream_conf(ngx_http_upstream_conf_t* upstream);
-
-char *ngx_merge_upstream_conf(
-	ngx_conf_t *cf,
-	ngx_http_upstream_conf_t* conf_upstream,
-	ngx_http_upstream_conf_t* prev_upstream);
-
-char *ngx_http_upstream_command(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
-
-ngx_int_t ngx_child_request_internal_handler(ngx_http_request_t *r);
+void ngx_child_request_init();
 
 #endif // _NGX_CHILD_HTTP_REQUEST_INCLUDED_

--- a/ngx_file_reader.h
+++ b/ngx_file_reader.h
@@ -12,7 +12,7 @@
 #endif
 
 // typedefs
-typedef void (*ngx_async_read_callback_t)(void* context, ngx_int_t rc, ssize_t bytes_read);
+typedef void (*ngx_async_read_callback_t)(void* context, ngx_int_t rc, ngx_buf_t* buf, ssize_t bytes_read);
 
 typedef struct {
 	ngx_http_request_t *r;
@@ -25,6 +25,7 @@ typedef struct {
 	ngx_flag_t use_aio;
 	ngx_async_read_callback_t read_callback;
 	void* callback_context;
+	ngx_buf_t* buf;
 #endif
 } ngx_file_reader_state_t;
 
@@ -52,7 +53,7 @@ ngx_int_t ngx_file_reader_init_async(
 
 ngx_int_t ngx_file_reader_dump_file_part(ngx_file_reader_state_t* state, off_t start, off_t end);
 
-ssize_t ngx_async_file_read(ngx_file_reader_state_t* state, u_char *buf, size_t size, off_t offset);
+ngx_int_t ngx_async_file_read(ngx_file_reader_state_t* state, ngx_buf_t *buf, size_t size, off_t offset);
 
 ngx_int_t ngx_file_reader_enable_directio(ngx_file_reader_state_t* state);
 

--- a/ngx_http_vod_conf.h
+++ b/ngx_http_vod_conf.h
@@ -16,7 +16,7 @@ struct ngx_http_vod_request_params_s;
 struct ngx_http_vod_loc_conf_s {
 	// config fields
 	ngx_http_vod_submodule_t submodule;
-	ngx_str_t child_request_location;
+	ngx_str_t upstream_location;
 	ngx_int_t(*request_handler)(ngx_http_request_t *r);
 	ngx_str_t multi_uri_suffix;
 	segmenter_conf_t segmenter;
@@ -29,17 +29,15 @@ struct ngx_http_vod_loc_conf_s {
 	size_t initial_read_size;
 	size_t max_moov_size;
 	size_t cache_buffer_size;
+	size_t max_upstream_headers_size;
 	ngx_flag_t ignore_edit_list;
-	ngx_http_upstream_conf_t upstream;
-	ngx_str_t upstream_host_header;
 	ngx_http_complex_value_t *upstream_extra_args;
 	ngx_shm_zone_t* path_mapping_cache_zone;
 	ngx_str_t path_response_prefix;
 	ngx_str_t path_response_postfix;
 	size_t max_mapping_response_size;
-	ngx_http_upstream_conf_t fallback_upstream;
-	ngx_str_t proxy_header_name;
-	ngx_str_t proxy_header_value;
+	ngx_str_t fallback_upstream_location;
+	ngx_table_elt_t proxy_header;
 
 	time_t last_modified_time;
 	ngx_hash_t  last_modified_types;
@@ -47,7 +45,7 @@ struct ngx_http_vod_loc_conf_s {
 
 	ngx_flag_t drm_enabled;
 	ngx_uint_t drm_clear_lead_segment_count;
-	ngx_http_upstream_conf_t drm_upstream;
+	ngx_str_t drm_upstream_location;
 	size_t drm_max_info_length;
 	ngx_shm_zone_t* drm_info_cache_zone;
 	ngx_http_complex_value_t *drm_request_uri;
@@ -64,7 +62,6 @@ struct ngx_http_vod_loc_conf_s {
 #endif
 
 	// derived fields
-	ngx_str_t proxy_header;
 	ngx_hash_t uri_params_hash;
 	ngx_hash_t pd_uri_params_hash;
 

--- a/test/nginx.conf
+++ b/test/nginx.conf
@@ -42,20 +42,16 @@ http {
 	gzip_types application/vnd.apple.mpegurl;
 		
 	# common vod settings
-	vod_child_request_path /__child_request__/;
-
 	vod_moov_cache moov_cache 512m;
 	vod_path_mapping_cache mapping_cache 5m;
-	vod_connect_timeout 5;
-	vod_send_timeout 5;
-	vod_read_timeout 5;
-	vod_fallback_connect_timeout 5;
-	vod_fallback_send_timeout 5;
-	vod_fallback_read_timeout 5;
-	vod_drm_connect_timeout 5;
-	vod_drm_send_timeout 5;
-	vod_drm_read_timeout 5;
+	vod_response_cache response_cache 128m;
+	vod_drm_info_cache drm_cache 64m;
 
+	# common proxy settings
+	proxy_connect_timeout 5;
+	proxy_send_timeout 5;
+	proxy_read_timeout 5;
+	
 	# common file caching / aio
 	open_file_cache max=100 inactive=5m;
 	open_file_cache_valid 2m;
@@ -63,46 +59,65 @@ http {
 	open_file_cache_errors on;
 	aio on;
 	
-    upstream kalapi {
+	upstream kalapi {
 		server localhost:80;
-    }
+	}
 	
-    upstream self {
-        server localhost:8001;
-        keepalive 32;
-    }	
+	upstream self {
+		server localhost:8001;
+		keepalive 32;
+	}	
 
-    upstream testapi {
+	upstream testapi {
 		server localhost:8002;
-    }
+	}
 
-    upstream testfallback {
-        server localhost:8003;
-    }
+	upstream fallback {
+		server localhost:8003;
+	}
 
-    upstream drmservice {
-        server localhost:8004;
-    }
+	upstream drmservice {
+		server localhost:8004;
+	}
 	
-    server {
-        listen       8001 backlog=1024;
-        server_name  localhost;
+	server {
+		listen	   8001 backlog=1024;
+		server_name  localhost;
 
 		# location for testing keep-alive - any requests to /self/xxx get proxied to xxx with keepalive
 		# the tested module "sees" keepalive connections even though the test code is not using keepalive
-        location /self/ {
-                proxy_pass http://self/;
-                proxy_http_version 1.1;
-                proxy_set_header Connection "";
-                proxy_set_header Host $http_host;
-        }
+		location /self/ {
+			proxy_pass http://self/;
+			proxy_http_version 1.1;
+			proxy_set_header Connection "";
+			proxy_set_header Host $http_host;
+		}
 		
 		# internal location for vod subrequests
-		location /__child_request__/ {
+		location /kalapi_proxy/ {
 			internal;
-			vod_child_request;
+			proxy_pass http://kalapi/;
+			proxy_set_header Host $http_host;
 		}
 
+		location /testapi_proxy/ {
+			internal;
+			proxy_pass http://testapi/;
+			proxy_set_header Host $http_host;
+		}
+
+		location /fallback_proxy/ {
+			internal;
+			proxy_pass http://fallback/;
+			proxy_set_header Host $http_host;
+		}
+
+		location /drmservice_proxy/ {
+			internal;
+			proxy_pass http://drmservice/;
+			proxy_set_header Host $http_host;
+		}
+		
 		# non-encrypted
 		
 		# local
@@ -120,7 +135,7 @@ http {
 		location ~ ^/mapped/hls/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod hls;
 			vod_mode mapped;
-			vod_upstream kalapi;
+			vod_upstream_location /kalapi_proxy/;
 			vod_upstream_extra_args "pathOnly=1";
 
 			add_header X-Me $hostname;
@@ -132,7 +147,7 @@ http {
 			vod hds;
 			vod_segment_duration 6000;
 			vod_mode mapped;
-			vod_upstream kalapi;
+			vod_upstream_location /kalapi_proxy/;
 			vod_upstream_extra_args "pathOnly=1";
 			vod_align_segments_to_key_frames on;
 
@@ -144,7 +159,7 @@ http {
 		location ~ ^/mapped/dash/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod dash;
 			vod_mode mapped;
-			vod_upstream kalapi;
+			vod_upstream_location /kalapi_proxy/;
 			vod_upstream_extra_args "pathOnly=1";
 			vod_segment_duration 4000;
 
@@ -162,7 +177,7 @@ http {
 		location ~ ^/mapped/mss/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod mss;
 			vod_mode mapped;
-			vod_upstream kalapi;
+			vod_upstream_location /kalapi_proxy/;
 			vod_upstream_extra_args "pathOnly=1";
 			vod_segment_duration 4000;
 
@@ -175,7 +190,7 @@ http {
 		location ~ ^/remote/hls/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod hls;
 			vod_mode remote;
-			vod_upstream kalapi;
+			vod_upstream_location /kalapi_proxy/;
 
 			add_header X-Me $hostname;
 			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
@@ -197,7 +212,7 @@ http {
 		location ~ ^/mapped/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod none;
 			vod_mode mapped;
-			vod_upstream kalapi;
+			vod_upstream_location /kalapi_proxy/;
 			vod_upstream_extra_args "pathOnly=1";
 
 			add_header X-Me $hostname;
@@ -209,7 +224,7 @@ http {
 		location ~ ^/remote/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod none;
 			vod_mode remote;
-			vod_upstream kalapi;
+			vod_upstream_location /kalapi_proxy/;
 
 			add_header X-Me $hostname;
 			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
@@ -221,7 +236,7 @@ http {
 			alias /web/content/;
 			vod none;
 			vod_mode local;
-			vod_fallback_upstream testfallback;
+			vod_fallback_upstream_location /fallback_proxy/;
 
 			add_header X-Me $hostname;
 			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
@@ -232,8 +247,8 @@ http {
 		location ~ ^/tmapped/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod none;
 			vod_mode mapped;
-			vod_upstream testapi;
-			vod_fallback_upstream testfallback;
+			vod_upstream_location /testapi_proxy/;
+			vod_fallback_upstream_location /fallback_proxy/;
 			vod_upstream_extra_args "pathOnly=1";
 
 			add_header X-Me $hostname;
@@ -245,7 +260,7 @@ http {
 		location ~ ^/tremote/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod none;
 			vod_mode remote;
-			vod_upstream testapi;
+			vod_upstream_location /testapi_proxy/;
 
 			add_header X-Me $hostname;
 			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
@@ -257,7 +272,7 @@ http {
 			alias /web/content/;
 			vod hls;
 			vod_mode local;
-			vod_fallback_upstream testfallback;
+			vod_fallback_upstream_location /fallback_proxy/;
 
 			add_header X-Me $hostname;
 			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
@@ -268,8 +283,8 @@ http {
 		location ~ ^/tmapped/hls/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod hls;
 			vod_mode mapped;
-			vod_upstream testapi;
-			vod_fallback_upstream testfallback;
+			vod_upstream_location /testapi_proxy/;
+			vod_fallback_upstream_location /fallback_proxy/;
 			vod_upstream_extra_args "pathOnly=1";
 
 			add_header X-Me $hostname;
@@ -281,7 +296,7 @@ http {
 		location ~ ^/tremote/hls/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod hls;
 			vod_mode remote;
-			vod_upstream testapi;
+			vod_upstream_location /testapi_proxy/;
 
 			add_header X-Me $hostname;
 			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
@@ -293,7 +308,7 @@ http {
 			alias /web/content/;
 			vod dash;
 			vod_mode local;
-			vod_fallback_upstream testfallback;
+			vod_fallback_upstream_location /fallback_proxy/;
 
 			add_header X-Me $hostname;
 			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
@@ -304,8 +319,8 @@ http {
 		location ~ ^/tmapped/dash/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod dash;
 			vod_mode mapped;
-			vod_upstream testapi;
-			vod_fallback_upstream testfallback;
+			vod_upstream_location /testapi_proxy/;
+			vod_fallback_upstream_location /fallback_proxy/;
 			vod_upstream_extra_args "pathOnly=1";
 
 			add_header X-Me $hostname;
@@ -317,7 +332,7 @@ http {
 		location ~ ^/tremote/dash/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod dash;
 			vod_mode remote;
-			vod_upstream testapi;
+			vod_upstream_location /testapi_proxy/;
 
 			add_header X-Me $hostname;
 			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
@@ -328,9 +343,9 @@ http {
 		location ~ ^/tremote/edash/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod dash;
 			vod_mode remote;
-			vod_upstream testapi;
+			vod_upstream_location /testapi_proxy/;
 			vod_drm_enabled on;
-			vod_drm_upstream drmservice;
+			vod_drm_upstream_location /drmservice_proxy/;
 
 			add_header X-Me $hostname;
 			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
@@ -342,7 +357,7 @@ http {
 			alias /web/content/;
 			vod hds;
 			vod_mode local;
-			vod_fallback_upstream testfallback;
+			vod_fallback_upstream_location /fallback_proxy/;
 
 			add_header X-Me $hostname;
 			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
@@ -353,8 +368,8 @@ http {
 		location ~ ^/tmapped/hds/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod hds;
 			vod_mode mapped;
-			vod_upstream testapi;
-			vod_fallback_upstream testfallback;
+			vod_upstream_location /testapi_proxy/;
+			vod_fallback_upstream_location /fallback_proxy/;
 			vod_upstream_extra_args "pathOnly=1";
 
 			add_header X-Me $hostname;
@@ -366,7 +381,7 @@ http {
 		location ~ ^/tremote/hds/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod hds;
 			vod_mode remote;
-			vod_upstream testapi;
+			vod_upstream_location /testapi_proxy/;
 
 			add_header X-Me $hostname;
 			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
@@ -378,7 +393,7 @@ http {
 			alias /web/content/;
 			vod mss;
 			vod_mode local;
-			vod_fallback_upstream testfallback;
+			vod_fallback_upstream_location /fallback_proxy/;
 
 			add_header X-Me $hostname;
 			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
@@ -389,8 +404,8 @@ http {
 		location ~ ^/tmapped/mss/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod mss;
 			vod_mode mapped;
-			vod_upstream testapi;
-			vod_fallback_upstream testfallback;
+			vod_upstream_location /testapi_proxy/;
+			vod_fallback_upstream_location /fallback_proxy/;
 			vod_upstream_extra_args "pathOnly=1";
 
 			add_header X-Me $hostname;
@@ -402,7 +417,7 @@ http {
 		location ~ ^/tremote/mss/p/\d+/(sp/\d+/)?serveFlavor/ {
 			vod mss;
 			vod_mode remote;
-			vod_upstream testapi;
+			vod_upstream_location /testapi_proxy/;
 
 			add_header X-Me $hostname;
 			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
@@ -428,7 +443,7 @@ http {
 			vod hls;
 			vod_mode mapped;
 			vod_secret_key password;
-			vod_upstream kalapi;
+			vod_upstream_location /kalapi_proxy/;
 			vod_upstream_extra_args "pathOnly=1";
 
 			add_header X-Me $hostname;
@@ -441,7 +456,7 @@ http {
 			vod hls;
 			vod_mode remote;
 			vod_secret_key password;
-			vod_upstream kalapi;
+			vod_upstream_location /kalapi_proxy/;
 
 			add_header X-Me $hostname;
 			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
@@ -454,7 +469,7 @@ http {
 			vod hls;
 			vod_mode local;
 			vod_secret_key password;
-			vod_fallback_upstream testfallback;
+			vod_fallback_upstream_location /fallback_proxy/;
 
 			add_header X-Me $hostname;
 			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
@@ -466,8 +481,8 @@ http {
 			vod hls;
 			vod_mode mapped;
 			vod_secret_key password;
-			vod_upstream testapi;
-			vod_fallback_upstream testfallback;
+			vod_upstream_location /testapi_proxy/;
+			vod_fallback_upstream_location /fallback_proxy/;
 			vod_upstream_extra_args "pathOnly=1";
 
 			add_header X-Me $hostname;
@@ -480,18 +495,18 @@ http {
 			vod hls;
 			vod_mode remote;
 			vod_secret_key password;
-			vod_upstream testapi;
+			vod_upstream_location /testapi_proxy/;
 
 			add_header X-Me $hostname;
 			add_header Last-Modified "Sun, 19 Nov 2000 08:52:00 GMT";
 			expires 100d;
 		}
 
-        # redirect server error pages to the static page /50x.html
-        #
-        error_page   500 502 503 504  /50x.html;
-        location = /50x.html {
-            root   html;
-        }
-    }
+		# redirect server error pages to the static page /50x.html
+		#
+		error_page   500 502 503 504  /50x.html;
+		location = /50x.html {
+			root   html;
+		}
+	}
 }

--- a/test/setup_test_entries.py
+++ b/test/setup_test_entries.py
@@ -212,8 +212,8 @@ TEST_CASES = [
         ('', 'clipTo/10000/a.mp4', 404, 'moov size 499999992 exceeds the max'),
     ]),
     ('TRUNCATED_MOOV', lambda: truncateFile(getAtomEndPos('moov') - 100), [
-        ('/hls', 'index.m3u8', 404, 'is smaller than moov end offset'),
-        ('', 'clipTo/10000/a.mp4', 404, 'is smaller than moov end offset'),
+        ('/hls', 'index.m3u8', 404, 'is smaller than moov size'),
+        ('', 'clipTo/10000/a.mp4', 404, 'is smaller than moov size'),
     ]),
     ('TRUNCATED_MDAT', lambda: truncateFile(getAtomPos('mdat') + 1000), [
         ('/hls', 'seg-1.ts', 0, 'no data was handled, probably a truncated file'),

--- a/vod/common.h
+++ b/vod/common.h
@@ -108,7 +108,6 @@ void vod_log_error(vod_uint_t level, vod_log_t *log, int err,
 #define vod_copy(dst, src, n) ngx_copy(dst, src, n)
 
 // memory alloc functions
-#define vod_memalign(pool, size, alignment) ngx_pmemalign(pool, size, alignment)
 #define vod_alloc(pool, size) ngx_palloc(pool, size)
 #define vod_free(pool, ptr) ngx_pfree(pool, ptr)
 #define vod_pool_cleanup_add(pool, size) ngx_pool_cleanup_add(pool, size)

--- a/vod/input/read_cache.h
+++ b/vod/input/read_cache.h
@@ -6,7 +6,8 @@
 
 // typedefs
 typedef struct {
-	u_char* buffer;
+	u_char* buffer_start;
+	u_char* buffer_pos;
 	uint32_t buffer_size;		// size of data read
 	void* source;				// opaque context that indicates from where the buffer should be read
 	uint64_t start_offset;
@@ -46,15 +47,13 @@ bool_t read_cache_get_from_cache(
 void read_cache_disable_buffer_reuse(
 	read_cache_state_t* state);
 
-vod_status_t read_cache_get_read_buffer(
+void read_cache_get_read_buffer(
 	read_cache_state_t* state, 
 	void** source,
 	uint64_t* out_offset,
 	u_char** buffer, 
 	uint32_t* size);
 	
-void read_cache_read_completed(
-	read_cache_state_t* state, 
-	ssize_t bytes_read);
+void read_cache_read_completed(read_cache_state_t* state, vod_buf_t* buf);
 
 #endif // __READ_CACHE_H__


### PR DESCRIPTION
instead of implementing an http upstream internally.
use of nginx's proxy_pass has several advantages, such as:
* support for ssl
* support for chunked transfer encoding
* support for url manipulations (e.g. remove the location part)
* support dynamic host resolution