### PR TITLE
The caching settings need to only be defined once.

### DIFF
--- a/conf/kaltura.conf.template
+++ b/conf/kaltura.conf.template
@@ -1,21 +1,4 @@
 
-		# common vod settings
-		vod_mode mapped;
-		vod_upstream_location /kalapi_proxy;
-		vod_upstream_extra_args "pathOnly=1";
-
-		# shared memory zones
-		vod_moov_cache moov_cache 512m;
-		vod_path_mapping_cache mapping_cache 64m;
-		vod_response_cache response_cache 64m;
-		vod_performance_counters perf_counters;
-
-		# common file caching / aio
-		open_file_cache max=1000 inactive=5m;
-		open_file_cache_valid 2m;
-		open_file_cache_min_uses 1;
-		open_file_cache_errors on;
-		aio on;
 		
 		# static files (crossdomain.xml, robots.txt etc.) + fallback to api
 		location / {

--- a/conf/nginx.conf.template
+++ b/conf/nginx.conf.template
@@ -42,6 +42,23 @@ http {
 
 	gzip  on;
 	gzip_types application/vnd.apple.mpegurl video/f4m application/dash+xml text/xml;
+	# common vod settings
+	vod_mode mapped;
+	vod_upstream_location /kalapi_proxy;
+	vod_upstream_extra_args "pathOnly=1";
+
+	# shared memory zones
+	vod_moov_cache moov_cache 512m;
+	vod_path_mapping_cache mapping_cache 64m;
+	vod_response_cache response_cache 64m;
+	vod_performance_counters perf_counters;
+
+	# common file caching / aio
+	open_file_cache max=1000 inactive=5m;
+	open_file_cache_valid 2m;
+	open_file_cache_min_uses 1;
+	open_file_cache_errors on;
+	aio on;
 
 	server {
 		listen @VOD_PACKAGER_PORT@;


### PR DESCRIPTION
Otherwise, one gets:
Restarting nginx: nginx: [emerg] duplicate zone "moov_cache" in
/opt/kaltura/nginx/conf/kaltura.conf:8
nginx: [emerg] duplicate zone "mapping_cache" in
/opt/kaltura/nginx/conf/kaltura.conf:9
nginx: [emerg] duplicate zone "response_cache" in
/opt/kaltura/nginx/conf/kaltura.conf:10

And when trying to make a request over SSL, a segfault is produced with
this trace:
    cache@entry=<error reading variable: Cannot access memory at address
0x7fff04f7e928>,
    key=0x7fff04f7eb80 <error: Cannot access memory at address
0x7fff04f7eb80>,
    key@entry=<error reading variable: Cannot access memory at address
0x7fff04f7e928>, buffer=0x7fff04f7e930,
    buffer@entry=<error reading variable: Cannot access memory at
address 0x7fff04f7e928>, buffer_size=0x7fff04f7e938,
    buffer_size@entry=<error reading variable: Cannot access memory at
address 0x7fff04f7e928>)
    at ./nginx-vod-module-1.5.1/ngx_buffer_cache.c:330
Cannot access memory at address 0x7fff04f7e928

Where line 330 is:
ngx_buffer_cache_sh_t *sh = cache->sh;

Taking this block out of kaltura.conf and placing it in the main config
before the 'server' blocks, works well and the requests work over both
HTTP and HTTPs.