### PR TITLE
bug fixes

### DIFF
--- a/ngx_child_http_request.c
+++ b/ngx_child_http_request.c
@@ -102,7 +102,7 @@ ngx_child_request_wev_handler(ngx_http_request_t *r)
 
 	// get the final error code
 	rc = ctx->error_code;
-	if (rc == NGX_OK)
+	if (rc == NGX_OK && is_in_memory(ctx))
 	{
 		if (u->headers_in.status_n != NGX_HTTP_OK && u->headers_in.status_n != NGX_HTTP_PARTIAL_CONTENT)
 		{
@@ -118,7 +118,7 @@ ngx_child_request_wev_handler(ngx_http_request_t *r)
 			}
 			rc = NGX_HTTP_BAD_GATEWAY;
 		}
-		else if (u->length != 0 && u->length != -1 && is_in_memory(ctx) && !u->headers_in.chunked)
+		else if (u->length != 0 && u->length != -1 && !u->headers_in.chunked)
 		{
 			ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
 				"ngx_child_request_wev_handler: upstream connection was closed with %O bytes left to read", u->length);

--- a/vod/buffer_pool.c
+++ b/vod/buffer_pool.c
@@ -75,8 +75,14 @@ buffer_pool_alloc(request_context_t* request_context, buffer_pool_t* buffer_pool
 	vod_pool_cleanup_t* cln;
 	void* result;
 
-	if (buffer_pool == NULL || buffer_pool->head == NULL)
+	if (buffer_pool == NULL)
 	{
+		return vod_alloc(request_context->pool, *buffer_size);
+	}
+
+	if (buffer_pool->head == NULL)
+	{
+		*buffer_size = buffer_pool->size;
 		return vod_alloc(request_context->pool, *buffer_size);
 	}
 


### PR DESCRIPTION
- ignore the HTTP status of dump requests (should not write an error log line)
- when a buffer pool is used, must allocate all buffers according to the size defined on the pool