### PR TITLE
ad stitching supporting features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Note: the list of changes below may not include all changes, it will include mostly "breaking" changes.
 	Usually, these are changes that require some update to nginx.conf in order to retain the existing behavior.
 
+## 2016/03/06 - ad stitching supporting features
+
+The following configuration settings were removed:
+* vod_path_mapping_cache - replaced by vod_mapping_cache
+* vod_live_path_mapping_cache - replaced by vod_live_mapping_cache
+	
 ## 2016/02/03 - added support for Matroska container
 
 The following configuration settings were removed:

--- a/conf/nginx.conf.template
+++ b/conf/nginx.conf.template
@@ -49,7 +49,7 @@ http {
 
 	# shared memory zones
 	vod_metadata_cache metadata_cache 512m;
-	vod_path_mapping_cache mapping_cache 64m;
+	vod_mapping_cache mapping_cache 64m;
 	vod_response_cache response_cache 64m;
 	vod_performance_counters perf_counters;
 

--- a/config
+++ b/config
@@ -105,7 +105,8 @@ NGX_ADDON_DEPS="$NGX_ADDON_DEPS                                     \
                 $ngx_addon_dir/vod/dash/edash_packager.h            \
                 $ngx_addon_dir/vod/dynamic_buffer.h                 \
                 $ngx_addon_dir/vod/filters/audio_filter.h           \
-                $ngx_addon_dir/vod/filters/concat_filter.h          \
+                $ngx_addon_dir/vod/filters/concat_clip.h            \
+                $ngx_addon_dir/vod/filters/dynamic_clip.h           \
                 $ngx_addon_dir/vod/filters/filter.h                 \
                 $ngx_addon_dir/vod/filters/gain_filter.h            \
                 $ngx_addon_dir/vod/filters/mix_filter.h             \
@@ -134,6 +135,7 @@ NGX_ADDON_DEPS="$NGX_ADDON_DEPS                                     \
                 $ngx_addon_dir/vod/input/read_cache.h               \
                 $ngx_addon_dir/vod/json_parser.h                    \
                 $ngx_addon_dir/vod/list_entry.h                     \
+                $ngx_addon_dir/vod/manifest_utils.h                 \
                 $ngx_addon_dir/vod/media_clip.h                     \
                 $ngx_addon_dir/vod/media_format.h                   \
                 $ngx_addon_dir/vod/media_set.h                      \
@@ -186,7 +188,8 @@ NGX_ADDON_SRCS="$NGX_ADDON_SRCS                                     \
                 $ngx_addon_dir/vod/dash/edash_packager.c            \
                 $ngx_addon_dir/vod/dynamic_buffer.c                 \
                 $ngx_addon_dir/vod/filters/audio_filter.c           \
-                $ngx_addon_dir/vod/filters/concat_filter.c          \
+                $ngx_addon_dir/vod/filters/concat_clip.c            \
+                $ngx_addon_dir/vod/filters/dynamic_clip.c           \
                 $ngx_addon_dir/vod/filters/filter.c                 \
                 $ngx_addon_dir/vod/filters/gain_filter.c            \
                 $ngx_addon_dir/vod/filters/mix_filter.c             \
@@ -208,6 +211,7 @@ NGX_ADDON_SRCS="$NGX_ADDON_SRCS                                     \
                 $ngx_addon_dir/vod/input/frames_source_memory.c     \
                 $ngx_addon_dir/vod/input/read_cache.c               \
                 $ngx_addon_dir/vod/json_parser.c                    \
+                $ngx_addon_dir/vod/manifest_utils.c                 \
                 $ngx_addon_dir/vod/media_format.c                   \
                 $ngx_addon_dir/vod/media_set_parser.c               \
                 $ngx_addon_dir/vod/mkv/ebml.c                       \

--- a/ngx_http_vod_conf.h
+++ b/ngx_http_vod_conf.h
@@ -42,10 +42,16 @@ struct ngx_http_vod_loc_conf_s {
 	size_t max_upstream_headers_size;
 	ngx_flag_t ignore_edit_list;
 	ngx_http_complex_value_t *upstream_extra_args;
-	ngx_buffer_cache_t* path_mapping_cache[CACHE_TYPE_COUNT];
+	ngx_buffer_cache_t* mapping_cache[CACHE_TYPE_COUNT];
+	ngx_buffer_cache_t* dynamic_mapping_cache;
 	ngx_str_t path_response_prefix;
 	ngx_str_t path_response_postfix;
 	size_t max_mapping_response_size;
+	ngx_http_complex_value_t* dynamic_clip_map_uri;
+	ngx_http_complex_value_t* source_clip_map_uri;
+	ngx_http_complex_value_t* redirect_segments_url;
+	ngx_http_complex_value_t* media_set_map_uri;
+	ngx_http_complex_value_t* apply_dynamic_mapping;
 	ngx_str_t fallback_upstream_location;
 	ngx_table_elt_t proxy_header;
 

--- a/ngx_http_vod_module.h
+++ b/ngx_http_vod_module.h
@@ -17,6 +17,9 @@ ngx_int_t ngx_http_vod_handler(ngx_http_request_t *r);
 ngx_int_t ngx_http_vod_set_filepath_var(ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data);
 ngx_int_t ngx_http_vod_set_suburi_var(ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data);
 ngx_int_t ngx_http_vod_set_sequence_id_var(ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data);
+ngx_int_t ngx_http_vod_set_clip_id_var(ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data);
+ngx_int_t ngx_http_vod_set_dynamic_mapping_var(ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data);
+ngx_int_t ngx_http_vod_set_request_params_var(ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data);
 
 // handlers
 ngx_int_t ngx_http_vod_local_request_handler(ngx_http_request_t *r);

--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -618,7 +618,6 @@ ngx_http_vod_parse_uri_path(
 	media_set_t* media_set)
 {
 	media_sequence_t* cur_sequence;
-	media_clip_source_t** cur_source_ptr;
 	media_clip_source_t* cur_source;
 	ngx_http_vod_multi_uri_t multi_uri;
 	media_clip_t** cur_clip_ptr;
@@ -661,7 +660,7 @@ ngx_http_vod_parse_uri_path(
 	}
 
 	cur_sequence = ngx_palloc(r->pool,
-		(sizeof(*cur_sequence) + sizeof(*cur_source_ptr) + sizeof(*cur_source) + sizeof(*cur_clip_ptr)) * uri_count);
+		(sizeof(*cur_sequence) + sizeof(*cur_source) + sizeof(*cur_clip_ptr)) * uri_count);
 	if (cur_sequence == NULL)
 	{
 		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
@@ -670,10 +669,7 @@ ngx_http_vod_parse_uri_path(
 	}
 	media_set->sequences = cur_sequence;
 
-	cur_source_ptr = (void*)(cur_sequence + uri_count);
-	media_set->sources = cur_source_ptr;
-
-	cur_source = (void*)(cur_source_ptr + uri_count);
+	cur_source = (void*)(cur_sequence + uri_count);
 
 	cur_clip_ptr = (void*)(cur_source + uri_count);
 
@@ -711,7 +707,9 @@ ngx_http_vod_parse_uri_path(
 		}
 		
 		*cur_clip_ptr = cur_clip;
-		*cur_source_ptr = cur_source;
+
+		cur_source->next = media_set->sources_head;
+		media_set->sources_head = cur_source;
 
 		cur_sequence->clips = cur_clip_ptr;
 		cur_sequence->index = i;
@@ -720,7 +718,6 @@ ngx_http_vod_parse_uri_path(
 		cur_sequence->id.len = 0;
 
 		cur_source++;
-		cur_source_ptr++;
 		cur_sequence++;
 		cur_clip_ptr++;
 	}
@@ -736,10 +733,8 @@ ngx_http_vod_parse_uri_path(
 
 	media_set->sequences_end = cur_sequence;
 	media_set->has_multi_sequences = (multi_uri.parts_count > 1);
-	media_set->sources_end = cur_source_ptr;
 	media_set->total_clip_count = 1;
 	media_set->clip_count = 1;
-	media_set->durations = NULL;
 
 	return NGX_OK;
 }

--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -619,6 +619,7 @@ ngx_http_vod_parse_uri_path(
 {
 	media_sequence_t* cur_sequence;
 	media_clip_source_t* cur_source;
+	media_clip_source_t* sources_head;
 	ngx_http_vod_multi_uri_t multi_uri;
 	media_clip_t** cur_clip_ptr;
 	media_clip_t* cur_clip;
@@ -673,6 +674,8 @@ ngx_http_vod_parse_uri_path(
 
 	cur_clip_ptr = (void*)(cur_source + uri_count);
 
+	sources_head = NULL;
+
 	parts[0] = multi_uri.prefix;
 	parts[2] = multi_uri.postfix;
 
@@ -708,8 +711,8 @@ ngx_http_vod_parse_uri_path(
 		
 		*cur_clip_ptr = cur_clip;
 
-		cur_source->next = media_set->sources_head;
-		media_set->sources_head = cur_source;
+		cur_source->next = sources_head;
+		sources_head = cur_source;
 
 		cur_sequence->clips = cur_clip_ptr;
 		cur_sequence->index = i;
@@ -731,6 +734,7 @@ ngx_http_vod_parse_uri_path(
 		return NGX_HTTP_BAD_REQUEST;
 	}
 
+	media_set->sources_head = sources_head;
 	media_set->sequences_end = cur_sequence;
 	media_set->has_multi_sequences = (multi_uri.parts_count > 1);
 	media_set->total_clip_count = 1;

--- a/ngx_http_vod_status.c
+++ b/ngx_http_vod_status.c
@@ -72,14 +72,14 @@ static ngx_http_vod_cache_info_t cache_infos[] = {
 		ngx_string("</live_response_cache>\r\n"),
 	},
 	{
-		offsetof(ngx_http_vod_loc_conf_t, path_mapping_cache[CACHE_TYPE_VOD]),
-		ngx_string("<path_mapping_cache>\r\n"),
-		ngx_string("</path_mapping_cache>\r\n"),
+		offsetof(ngx_http_vod_loc_conf_t, mapping_cache[CACHE_TYPE_VOD]),
+		ngx_string("<mapping_cache>\r\n"),
+		ngx_string("</mapping_cache>\r\n"),
 	},
 	{
-		offsetof(ngx_http_vod_loc_conf_t, path_mapping_cache[CACHE_TYPE_LIVE]),
-		ngx_string("<live_path_mapping_cache>\r\n"),
-		ngx_string("</live_path_mapping_cache>\r\n"),
+		offsetof(ngx_http_vod_loc_conf_t, mapping_cache[CACHE_TYPE_LIVE]),
+		ngx_string("<live_mapping_cache>\r\n"),
+		ngx_string("</live_mapping_cache>\r\n"),
 	},
 	{
 		offsetof(ngx_http_vod_loc_conf_t, drm_info_cache),

--- a/ngx_http_vod_submodule.h
+++ b/ngx_http_vod_submodule.h
@@ -51,11 +51,8 @@ typedef struct {
 	request_context_t request_context;
 	media_set_t media_set;
 	request_params_t request_params;
-	const struct ngx_http_vod_request_s* request;
 	ngx_http_request_t* r;
 	struct ngx_http_vod_loc_conf_s* conf;
-	media_sequence_t* cur_sequence;
-	media_clip_source_t** cur_source;
 } ngx_http_vod_submodule_context_t;
 
 // submodule request

--- a/ngx_perf_counters_x.h
+++ b/ngx_perf_counters_x.h
@@ -1,6 +1,7 @@
 PC(FETCH_CACHE,				fetch_cache)
 PC(STORE_CACHE,				store_cache)
 PC(MAP_PATH,				map_path)
+PC(PARSE_MEDIA_SET,			parse_media_set)
 PC(GET_DRM_INFO,			get_drm_info)
 PC(OPEN_FILE,				open_file)
 PC(ASYNC_OPEN_FILE,			async_open_file)

--- a/test/main.py
+++ b/test/main.py
@@ -1011,7 +1011,7 @@ class MappedTestSuite(ModeTestSuite):
     def testEmptyPathMappingResponse(self):
         TcpServer(API_SERVER_PORT, lambda s: socketSendAndShutdown(s, getHttpResponse('')))
         assertRequestFails(self.getUrl(HLS_PREFIX, HLS_PLAYLIST_FILE), 404)
-        self.logTracker.assertContains('empty path mapping response')
+        self.logTracker.assertContains('empty mapping response')
 
     def testUnexpectedPathResponse(self):
         TcpServer(API_SERVER_PORT, lambda s: socketSendAndShutdown(s, getHttpResponse('abcde')))
@@ -1038,14 +1038,14 @@ class MappedTestSuite(ModeTestSuite):
             response = urllib2.urlopen(url)            
             assertEquals(response.info().getheader('Content-Type'), contentType)            
             uncachedResponse = response.read()
-            logTracker.assertContains('path mapping cache miss')
+            logTracker.assertContains('mapping cache miss')
 
             #cached
             logTracker = LogTracker()
             response = urllib2.urlopen(url)
             assertEquals(response.info().getheader('Content-Type'), contentType)            
             cachedResponse = response.read()
-            logTracker.assertContains(['path mapping cache hit', 'response cache hit'])
+            logTracker.assertContains(['mapping cache hit', 'response cache hit'])
 
             assert(cachedResponse == uncachedResponse)
                    

--- a/test/nginx.conf
+++ b/test/nginx.conf
@@ -43,7 +43,7 @@ http {
 		
 	# common vod settings
 	vod_metadata_cache metadata_cache 512m;
-	vod_path_mapping_cache mapping_cache 5m;
+	vod_mapping_cache mapping_cache 5m;
 	vod_response_cache response_cache 128m;
 	vod_drm_info_cache drm_cache 64m;
 

--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -1559,7 +1559,7 @@ dash_packager_get_earliest_pres_time(media_set_t* media_set, media_track_t* trac
 	
 	if (!media_set->use_discontinuity)
 	{
-		result += rescale_time(track->clip_start_time, 1000, track->media_info.timescale);
+		result += rescale_time_neg(track->clip_start_time, 1000, track->media_info.timescale);
 	}
 
 	if (track->frame_count > 0)

--- a/vod/filters/audio_filter.c
+++ b/vod/filters/audio_filter.c
@@ -521,7 +521,7 @@ audio_filter_walk_filters_prepare_init(
 		switch (clip->type)
 		{
 		case MEDIA_CLIP_MIX_FILTER:
-		case MEDIA_CLIP_CONCAT_FILTER:
+		case MEDIA_CLIP_CONCAT:
 			// in case of mixing a single clip or concat, skip the filter
 			*clip_ptr = last_source;
 			return VOD_OK;

--- a/vod/filters/concat_clip.c
+++ b/vod/filters/concat_clip.c
@@ -1,14 +1,20 @@
-#include "concat_filter.h"
+#include "concat_clip.h"
 #include "../media_set_parser.h"
 #include "../parse_utils.h"
 
 // constants
 #define MAX_CONCAT_ELEMENTS (10000)
 
+// typedefs
+typedef struct {
+	media_clip_t base;
+} media_clip_concat_t;
+
 // enums
 enum {
 	CONCAT_PARAM_BASE_PATH,
 	CONCAT_PARAM_PATHS,
+	CONCAT_PARAM_CLIP_IDS,
 	CONCAT_PARAM_DURATIONS,
 	CONCAT_PARAM_OFFSET,
 	CONCAT_PARAM_TRACKS,
@@ -16,15 +22,11 @@ enum {
 	CONCAT_PARAM_COUNT
 };
 
-// typedefs
-typedef struct {
-	media_clip_t base;
-} media_clip_concat_filter_t;
-
 // constants
-static json_object_key_def_t concat_filter_params[] = {
+static json_object_key_def_t concat_clip_params[] = {
 	{ vod_string("basePath"),	VOD_JSON_STRING,	CONCAT_PARAM_BASE_PATH },
 	{ vod_string("paths"),		VOD_JSON_ARRAY,		CONCAT_PARAM_PATHS },
+	{ vod_string("clipIds"),	VOD_JSON_ARRAY,		CONCAT_PARAM_CLIP_IDS },
 	{ vod_string("durations"),	VOD_JSON_ARRAY,		CONCAT_PARAM_DURATIONS },
 	{ vod_string("offset"),		VOD_JSON_INT,		CONCAT_PARAM_OFFSET },
 	{ vod_string("tracks"),		VOD_JSON_STRING,	CONCAT_PARAM_TRACKS },	
@@ -32,22 +34,23 @@ static json_object_key_def_t concat_filter_params[] = {
 };
 
 // globals
-static vod_hash_t concat_filter_hash;
+static vod_hash_t concat_clip_hash;
 
 vod_status_t
-concat_filter_parse(
+concat_clip_parse(
 	void* ctx,
 	vod_json_value_t* element,
 	void** result)
 {
 	media_filter_parse_context_t* context = ctx;
-	media_clip_concat_filter_t* filter;
-	media_clip_source_t** source_ptr;
+	media_clip_concat_t* clip;
+	media_clip_source_t* sources_list_head;
 	media_clip_source_t* cur_source;
 	media_clip_source_t* sources;
 	vod_json_value_t* array_elts;
 	vod_json_value_t* params[CONCAT_PARAM_COUNT];
 	media_range_t* range;
+	vod_array_t* paths;
 	vod_array_t* array;
 	vod_str_t* src_str;
 	u_char* end_pos;
@@ -67,47 +70,64 @@ concat_filter_parse(
 	vod_status_t rc;
 
 	vod_log_debug0(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
-		"concat_filter_parse: started");
+		"concat_clip_parse: started");
 
 	// get the required fields
 	vod_memzero(params, sizeof(params));
 	vod_json_get_object_values(
 		element,
-		&concat_filter_hash,
+		&concat_clip_hash,
 		params);
 
 	// validate the paths and durations arrays
-	if (params[CONCAT_PARAM_PATHS] == NULL || params[CONCAT_PARAM_DURATIONS] == NULL)
+	if (params[CONCAT_PARAM_PATHS] != NULL)
+	{
+		paths = &params[CONCAT_PARAM_PATHS]->v.arr;
+		sources_list_head = context->sources_head;
+	}
+	else if (params[CONCAT_PARAM_CLIP_IDS] != NULL)
+	{
+		paths = &params[CONCAT_PARAM_CLIP_IDS]->v.arr;
+		sources_list_head = context->mapped_sources_head;
+	}
+	else
 	{
 		vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-			"concat_filter_parse: \"paths\" and \"durations\" are mandatory for concat");
+			"concat_clip_parse: must specify either \"paths\" or \"clipId\" for concat");
 		return VOD_BAD_MAPPING;
 	}
 
-	if (params[CONCAT_PARAM_PATHS]->v.arr.nelts != params[CONCAT_PARAM_DURATIONS]->v.arr.nelts)
+	if (params[CONCAT_PARAM_DURATIONS] == NULL)
 	{
 		vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-			"concat_filter_parse: \"paths\" element count %ui different than \"durations\" element count %ui", 
-			params[CONCAT_PARAM_PATHS]->v.arr.nelts,
+			"concat_clip_parse: \"durations\" is mandatory for concat");
+		return VOD_BAD_MAPPING;
+	}
+
+	if (paths->nelts != params[CONCAT_PARAM_DURATIONS]->v.arr.nelts)
+	{
+		vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
+			"concat_clip_parse: \"paths\" element count %ui different than \"durations\" element count %ui", 
+			paths->nelts,
 			params[CONCAT_PARAM_DURATIONS]->v.arr.nelts);
 		return VOD_BAD_MAPPING;
 	}
 
-	if (params[CONCAT_PARAM_PATHS]->v.arr.nelts > MAX_CONCAT_ELEMENTS)
+	if (paths->nelts > MAX_CONCAT_ELEMENTS)
 	{
 		vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-			"concat_filter_parse: number of concat elements %ui too big",
-			params[CONCAT_PARAM_PATHS]->v.arr.nelts);
+			"concat_clip_parse: number of concat elements %ui too big",
+			paths->nelts);
 		return VOD_BAD_MAPPING;
 	}
 
 	if (context->range == NULL)
 	{
 		// no range, just use the first clip
-		if (params[CONCAT_PARAM_PATHS]->v.arr.nelts <= 0)
+		if (paths->nelts <= 0)
 		{
 			vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-				"concat_filter_parse: \"paths\" array is empty");
+				"concat_clip_parse: \"paths\" array is empty");
 			return VOD_BAD_MAPPING;
 		}
 
@@ -129,7 +149,7 @@ concat_filter_parse(
 			if (params[CONCAT_PARAM_OFFSET]->v.num.nom < INT_MIN)
 			{
 				vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-					"concat_filter_parse: offset %L too small", params[CONCAT_PARAM_OFFSET]->v.num.nom);
+					"concat_clip_parse: offset %L too small", params[CONCAT_PARAM_OFFSET]->v.num.nom);
 				return VOD_BAD_MAPPING;
 			}
 
@@ -137,7 +157,7 @@ concat_filter_parse(
 			if ((int64_t)end <= offset)
 			{
 				vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-					"concat_filter_parse: concat offset %D larger than end offset %uL", offset, end);
+					"concat_clip_parse: concat offset %D larger than end offset %uL", offset, end);
 				return VOD_BAD_REQUEST;
 			}
 		}
@@ -154,7 +174,7 @@ concat_filter_parse(
 			if (array_elts[i].type != VOD_JSON_INT)
 			{
 				vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-					"concat_filter_parse: invalid type %d of \"durations\" element, must be int", 
+					"concat_clip_parse: invalid type %d of \"durations\" element, must be int", 
 					array_elts[i].type);
 				return VOD_BAD_MAPPING;
 			}
@@ -162,7 +182,7 @@ concat_filter_parse(
 			if (array_elts[i].v.num.nom > INT_MAX - vod_max(offset, 0))
 			{
 				vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-					"concat_filter_parse: duration value %uL too big",
+					"concat_clip_parse: duration value %uL too big",
 					array_elts[i].v.num.nom);
 				return VOD_BAD_MAPPING;
 			}
@@ -192,7 +212,7 @@ concat_filter_parse(
 		if (min_index == UINT_MAX)
 		{
 			vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-				"concat_filter_parse: start offset %uL greater than the sum of the durations array",
+				"concat_clip_parse: start offset %uL greater than the sum of the durations array",
 				start);
 			return VOD_BAD_MAPPING;
 		}
@@ -204,7 +224,7 @@ concat_filter_parse(
 		if (range == NULL)
 		{
 			vod_log_debug0(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
-				"concat_filter_parse: vod_alloc failed (1)");
+				"concat_clip_parse: vod_alloc failed (1)");
 			return VOD_ALLOC_FAILED;
 		}
 
@@ -236,7 +256,7 @@ concat_filter_parse(
 		if (parse_utils_extract_track_tokens(src_str->data, end_pos, tracks_mask) != end_pos)
 		{
 			vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-				"concat_filter_parse: failed to parse tracks specification");
+				"concat_clip_parse: failed to parse tracks specification");
 			return VOD_BAD_MAPPING;
 		}
 	}
@@ -261,30 +281,22 @@ concat_filter_parse(
 	if (sources == NULL)
 	{
 		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
-			"concat_filter_parse: vod_alloc failed (2)");
+			"concat_clip_parse: vod_alloc failed (2)");
 		return VOD_ALLOC_FAILED;
 	}
 	vod_memzero(sources, sizeof(sources[0]) * clip_count);
 	cur_source = sources;
 
-	source_ptr = vod_array_push_n(&context->sources, clip_count);
-	if (source_ptr == NULL)
-	{
-		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
-			"concat_filter_parse: vod_array_push_n failed");
-		return VOD_ALLOC_FAILED;
-	}
-
 	offset = context->sequence_offset + start_offset;
 
-	array_elts = params[CONCAT_PARAM_PATHS]->v.arr.elts;
+	array_elts = paths->elts;
 	for (i = min_index; i <= max_index; i++)
 	{
 		// decode the path
 		if (array_elts[i].type != VOD_JSON_STRING)
 		{
 			vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-				"concat_filter_parse: invalid type %d of \"paths\" element, must be string",
+				"concat_clip_parse: invalid type %d of \"paths\" element, must be string",
 				array_elts[i].type);
 			return VOD_BAD_MAPPING;
 		}
@@ -295,7 +307,7 @@ concat_filter_parse(
 		if (dest_str.data == NULL)
 		{
 			vod_log_debug0(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
-				"concat_filter_parse: vod_alloc failed (3)");
+				"concat_clip_parse: vod_alloc failed (3)");
 			return VOD_ALLOC_FAILED;
 		}
 		dest_str.len = 0;
@@ -306,7 +318,7 @@ concat_filter_parse(
 			if (rc != VOD_JSON_OK)
 			{
 				vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-					"concat_filter_parse: vod_json_decode_string failed %i", rc);
+					"concat_clip_parse: vod_json_decode_string failed %i", rc);
 				return VOD_BAD_MAPPING;
 			}
 		}
@@ -315,14 +327,15 @@ concat_filter_parse(
 		if (rc != VOD_JSON_OK)
 		{
 			vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-				"concat_filter_parse: vod_json_decode_string failed %i", rc);
+				"concat_clip_parse: vod_json_decode_string failed %i", rc);
 			return VOD_BAD_MAPPING;
 		}
 
 		dest_str.data[dest_str.len] = '\0';
 
 		// initialize the source
-		*source_ptr++ = cur_source;
+		cur_source->next = sources_list_head;
+		sources_list_head = cur_source;
 
 		cur_source->base.type = MEDIA_CLIP_SOURCE;
 
@@ -334,7 +347,7 @@ concat_filter_parse(
 		cur_source->stripped_uri = cur_source->mapped_uri = dest_str;
 
 		vod_log_debug3(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
-			"concat_filter_parse: parsed clip source - path=%V tracks[v]=0x%uxD tracks[a]=0x%uxD",
+			"concat_clip_parse: parsed clip source - path=%V tracks[v]=0x%uxD tracks[a]=0x%uxD",
 			&cur_source->mapped_uri,
 			cur_source->tracks_mask[MEDIA_TYPE_VIDEO],
 			cur_source->tracks_mask[MEDIA_TYPE_AUDIO]);
@@ -351,43 +364,52 @@ concat_filter_parse(
 		range++;
 	}
 
-	// in case of a single clip, just return the first source (no need for a concat filter)
+	// in case of a single clip, just return the first source (no need for a concat clip)
 	if (clip_count == 1)
 	{
 		*result = &sources[0].base;
 		goto done;
 	}
 
-	// return a concat filter
-	filter = vod_alloc(context->request_context->pool, sizeof(*filter) + sizeof(media_clip_t*) * clip_count);
-	if (filter == NULL)
+	// return a concat clip
+	clip = vod_alloc(context->request_context->pool, sizeof(*clip) + sizeof(media_clip_t*) * clip_count);
+	if (clip == NULL)
 	{
 		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
-			"concat_filter_parse: vod_alloc failed (4)");
+			"concat_clip_parse: vod_alloc failed (4)");
 		return VOD_ALLOC_FAILED;
 	}
 
-	filter->base.type = MEDIA_CLIP_CONCAT_FILTER;
-	filter->base.audio_filter = NULL;
+	clip->base.type = MEDIA_CLIP_CONCAT;
+	clip->base.audio_filter = NULL;
 
-	filter->base.sources = (void*)(filter + 1);
+	clip->base.sources = (void*)(clip + 1);
 	for (i = 0; i < clip_count; i++)
 	{
-		filter->base.sources[i] = &sources[i].base;
+		clip->base.sources[i] = &sources[i].base;
 	}
-	filter->base.source_count = clip_count;
+	clip->base.source_count = clip_count;
 
-	*result = &filter->base;
+	*result = &clip->base;
 
 done:
 
+	if (params[CONCAT_PARAM_PATHS] != NULL)
+	{
+		context->sources_head = sources_list_head;
+	}
+	else if (params[CONCAT_PARAM_CLIP_IDS] != NULL)
+	{
+		context->mapped_sources_head = sources_list_head;
+	}
+
 	vod_log_debug0(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
-		"concat_filter_parse: done");
+		"concat_clip_parse: done");
 	return VOD_OK;
 }
 
 vod_status_t
-concat_filter_concat(
+concat_clip_concat(
 	request_context_t* request_context, 
 	media_clip_t* clip)
 {
@@ -405,7 +427,7 @@ concat_filter_concat(
 		if (src_clip->track_array.track_count[MEDIA_TYPE_VIDEO] != dest_clip->track_array.track_count[MEDIA_TYPE_VIDEO])
 		{
 			vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-				"concat_filter_concat: concatenated sources have a different number of video tracks %uD vs %uD",
+				"concat_clip_concat: concatenated sources have a different number of video tracks %uD vs %uD",
 				src_clip->track_array.track_count[MEDIA_TYPE_VIDEO],
 				dest_clip->track_array.track_count[MEDIA_TYPE_VIDEO]);
 			return VOD_BAD_MAPPING;
@@ -414,7 +436,7 @@ concat_filter_concat(
 		if (src_clip->track_array.track_count[MEDIA_TYPE_AUDIO] != dest_clip->track_array.track_count[MEDIA_TYPE_AUDIO])
 		{
 			vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-				"concat_filter_concat: concatenated sources have a different number of audio tracks %uD vs %uD",
+				"concat_clip_concat: concatenated sources have a different number of audio tracks %uD vs %uD",
 				src_clip->track_array.track_count[MEDIA_TYPE_AUDIO],
 				dest_clip->track_array.track_count[MEDIA_TYPE_AUDIO]);
 			return VOD_BAD_MAPPING;
@@ -448,7 +470,7 @@ concat_filter_concat(
 }
 
 vod_status_t
-concat_filter_parser_init(
+concat_clip_parser_init(
 	vod_pool_t* pool,
 	vod_pool_t* temp_pool)
 {
@@ -457,10 +479,10 @@ concat_filter_parser_init(
 	rc = vod_json_init_hash(
 		pool,
 		temp_pool,
-		"concat_filter_hash",
-		concat_filter_params,
-		sizeof(concat_filter_params[0]),
-		&concat_filter_hash);
+		"concat_clip_hash",
+		concat_clip_params,
+		sizeof(concat_clip_params[0]),
+		&concat_clip_hash);
 	if (rc != VOD_OK)
 	{
 		return rc;

--- a/vod/filters/concat_clip.h
+++ b/vod/filters/concat_clip.h
@@ -1,22 +1,22 @@
-#ifndef __CONCAT_FILTER_H__
-#define __CONCAT_FILTER_H__
+#ifndef __CONCAT_CLIP_H__
+#define __CONCAT_CLIP_H__
 
 // includes
 #include "../json_parser.h"
 #include "../media_clip.h"
 
 // functions
-vod_status_t concat_filter_parse(
+vod_status_t concat_clip_parse(
 	void* context,
 	vod_json_value_t* element,
 	void** result);
 
-vod_status_t concat_filter_concat(
+vod_status_t concat_clip_concat(
 	request_context_t* request_context,
 	media_clip_t* clip);
 
-vod_status_t concat_filter_parser_init(
+vod_status_t concat_clip_parser_init(
 	vod_pool_t* pool,
 	vod_pool_t* temp_pool);
 
-#endif // __CONCAT_FILTER_H__
+#endif // __CONCAT_CLIP_H__

--- a/vod/filters/dynamic_clip.c
+++ b/vod/filters/dynamic_clip.c
@@ -1,0 +1,505 @@
+#include "dynamic_clip.h"
+#include "concat_clip.h"
+#include "../media_set_parser.h"
+#include "../parse_utils.h"
+
+#define MAX_DYNAMIC_CLIP_SOURCE_COUNT (128)
+
+// constants
+static json_object_value_def_t dynamic_clip_params[] = {
+	{ vod_string("id"), VOD_JSON_STRING, offsetof(media_clip_dynamic_t, id), media_set_parse_null_term_string },
+	{ vod_null_string, 0, 0, NULL }
+};
+
+// globals
+static vod_str_t dynamic_clip_no_mapping = vod_string("none");
+static vod_hash_t dynamic_clip_hash;
+
+vod_status_t
+dynamic_clip_parse(
+	void* ctx,
+	vod_json_value_t* element,
+	void** result)
+{
+	media_filter_parse_context_t* context = ctx;
+	media_clip_dynamic_t* filter;
+	vod_status_t rc;
+
+	vod_log_debug0(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
+		"dynamic_clip_parse: started");
+
+	filter = vod_alloc(context->request_context->pool, sizeof(*filter));
+	if (filter == NULL)
+	{
+		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
+			"dynamic_clip_parse: vod_alloc failed");
+		return VOD_ALLOC_FAILED;
+	}
+
+	filter->base.type = MEDIA_CLIP_DYNAMIC;
+	filter->base.audio_filter = NULL;
+	filter->base.sources = NULL;
+	filter->base.source_count = 0;
+
+	filter->id.len = 0;
+	rc = vod_json_parse_object_values(
+		element,
+		&dynamic_clip_hash,
+		context,
+		filter);
+	if (rc != VOD_OK)
+	{
+		return rc;
+	}
+
+	if (filter->id.len == 0)
+	{
+		vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
+			"dynamic_clip_parse: \"id\" is mandatory for dynamic filter");
+		return VOD_BAD_MAPPING;
+	}
+
+	filter->next = context->dynamic_clips_head;
+	context->dynamic_clips_head = filter;
+
+	filter->sequence = context->sequence;
+	filter->sequence_offset = context->sequence_offset;
+	filter->duration = context->duration;
+	filter->range = context->range;
+
+	*result = &filter->base;
+
+	vod_log_debug0(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
+		"dynamic_clip_parse: done");
+
+	return VOD_OK;
+}
+
+vod_status_t
+dynamic_clip_parser_init(
+	vod_pool_t* pool,
+	vod_pool_t* temp_pool)
+{
+	vod_status_t rc;
+
+	rc = vod_json_init_hash(
+		pool,
+		temp_pool,
+		"dynamic_clip_hash",
+		dynamic_clip_params,
+		sizeof(dynamic_clip_params[0]),
+		&dynamic_clip_hash);
+	if (rc != VOD_OK)
+	{
+		return rc;
+	}
+
+	return VOD_OK;
+}
+
+vod_status_t
+dynamic_clip_apply_mapping_json(
+	media_clip_dynamic_t* clip, 
+	request_context_t* request_context,
+	u_char* mapping, 
+	media_set_t* media_set)
+{
+	media_filter_parse_context_t context;
+	vod_json_value_t json;
+	media_clip_t* concat_clip;
+	vod_status_t rc;
+	u_char error[128];
+
+	rc = vod_json_parse(request_context->pool, mapping, &json, error, sizeof(error));
+	if (rc != VOD_JSON_OK)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"dynamic_clip_apply_mapping_json: failed to parse json %i: %s", rc, error);
+		return VOD_BAD_MAPPING;
+	}
+
+	context.request_context = request_context;
+	context.sources_head = media_set->sources_head;
+	context.mapped_sources_head = media_set->mapped_sources_head;
+	context.sequence = clip->sequence;
+	context.sequence_offset = clip->sequence_offset;
+	context.duration = clip->duration;
+	context.range = clip->range;
+
+	rc = concat_clip_parse(&context, &json, (void**)&concat_clip);
+	if (rc != VOD_OK)
+	{
+		vod_log_debug1(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
+			"dynamic_clip_apply_mapping_json: concat_clip_parse failed %i", rc);
+		return rc;
+	}
+
+	media_set->sources_head = context.sources_head;
+	media_set->mapped_sources_head = context.mapped_sources_head;
+
+	clip->base.type = MEDIA_CLIP_CONCAT;
+	if (concat_clip->type == MEDIA_CLIP_SOURCE)
+	{
+		clip->base.sources = vod_alloc(request_context->pool, sizeof(clip->base.sources[0]));
+		if (clip->base.sources == NULL)
+		{
+			vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
+				"dynamic_clip_apply_mapping_json: vod_alloc failed");
+			return VOD_ALLOC_FAILED;
+		}
+		clip->base.sources[0] = concat_clip;
+		clip->base.source_count = 1;
+	}
+	else
+	{
+		clip->base.sources = concat_clip->sources;
+		clip->base.source_count = concat_clip->source_count;
+	}
+
+	return VOD_OK;
+}
+
+vod_status_t
+dynamic_clip_get_mapping_string(
+	request_context_t* request_context,
+	media_clip_dynamic_t* dynamic_clips_head, 
+	vod_str_t* result)
+{
+	media_clip_dynamic_t* cur_clip;
+	media_clip_source_t* cur_source;
+	size_t alloc_size;
+	uint32_t i;
+	u_char* p;
+
+	// calculate the alloc size
+	alloc_size = 0;
+	for (cur_clip = dynamic_clips_head; cur_clip != NULL; cur_clip = cur_clip->next)
+	{
+		if (cur_clip->base.source_count == 0)
+		{
+			continue;
+		}
+
+		alloc_size += sizeof("--") - 1 + VOD_INT32_LEN + cur_clip->id.len;
+
+		for (i = 0; i < cur_clip->base.source_count; i++)
+		{
+			cur_source = (media_clip_source_t*)cur_clip->base.sources[i];
+			alloc_size += sizeof("--") - 1 + VOD_INT64_LEN + cur_source->mapped_uri.len;
+		}
+	}
+
+	if (alloc_size == 0)
+	{
+		*result = dynamic_clip_no_mapping;
+		return VOD_OK;
+	}
+
+	// allocate the buffer
+	p = vod_alloc(request_context->pool, alloc_size);
+	if (p == NULL)
+	{
+		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
+			"dynamic_clip_get_mapping_string: vod_alloc failed");
+		return VOD_ALLOC_FAILED;
+	}
+	result->data = p;
+
+	// build the value
+	for (cur_clip = dynamic_clips_head; cur_clip != NULL; cur_clip = cur_clip->next)
+	{
+		if (cur_clip->base.source_count == 0)
+		{
+			continue;
+		}
+
+		if (p > result->data)
+		{
+			*p++ = '-';
+		}
+
+		p = vod_sprintf(p, "%V-%uD", &cur_clip->id, cur_clip->base.source_count);
+
+		for (i = 0; i < cur_clip->base.source_count; i++)
+		{
+			cur_source = (media_clip_source_t*)cur_clip->base.sources[i];
+			p = vod_sprintf(p, "-%V-%uL", 
+				&cur_source->mapped_uri, 
+				cur_source->sequence_offset - cur_clip->sequence_offset);
+		}
+	}
+
+	*p = '\0';
+
+	result->len = p - result->data;
+
+	return VOD_OK;
+}
+
+static vod_status_t
+dynamic_clip_extract_token(
+	request_context_t* request_context, 
+	u_char** cur, 
+	u_char* end, 
+	vod_str_t* result)
+{
+	u_char* p = *cur;
+
+	result->data = p;
+	p = memchr(p, '-', end - p);
+	if (p == NULL)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"dynamic_clip_extract_token: delimiter (-) not found");
+		return VOD_BAD_REQUEST;
+	}
+	result->len = p - result->data;
+	if (result->len <= 0)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"dynamic_clip_extract_token: zero length token");
+		return VOD_BAD_REQUEST;
+	}
+
+	*cur = p + 1;		// skip the -
+
+	return VOD_OK;
+}
+
+static vod_status_t
+dynamic_clip_apply_mapping_string_clip(
+	request_context_t* request_context,
+	media_set_t* media_set,
+	media_clip_dynamic_t* clip, 
+	uint32_t source_count,
+	u_char** cur, 
+	u_char* end)
+{
+	media_clip_source_t* sources_list_head;
+	media_clip_source_t* cur_source;
+	media_range_t* range;
+	media_clip_t** cur_source_ptr;
+	vod_str_t clip_id;
+	uint32_t last_offset;
+	uint32_t offset;
+	u_char* p = *cur;
+	uint64_t range_start;
+	uint64_t range_end;
+	uint32_t i;
+	vod_status_t rc;
+
+	if (clip->range == NULL)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"dynamic_clip_apply_mapping_string_clip: manifest request issued on a location with vod_apply_dynamic_mapping set");
+		return VOD_BAD_REQUEST;
+	}
+
+	range_start = clip->range->start;
+	range_end = clip->range->end;
+
+	range = vod_alloc(request_context->pool, (sizeof(range[0]) + sizeof(cur_source[0]) + sizeof(cur_source_ptr[0])) * source_count);
+	if (range == NULL)
+	{
+		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
+			"dynamic_clip_apply_mapping_string_clip: vod_alloc failed");
+		return VOD_ALLOC_FAILED;
+	}
+
+	cur_source = (void*)(range + source_count);
+	vod_memzero(cur_source, sizeof(cur_source[0]) * source_count);
+
+	cur_source_ptr = (void*)(cur_source + source_count);
+	clip->base.sources = cur_source_ptr;
+
+	sources_list_head = media_set->mapped_sources_head;
+
+	for (i = 0; i < source_count; i++)
+	{
+		// clip id
+		rc = dynamic_clip_extract_token(request_context, &p, end, &clip_id);
+		if (rc != VOD_OK)
+		{
+			return rc;
+		}
+
+		// offset
+		p = parse_utils_extract_uint32_token(p, end, &offset);
+		if (p < end)
+		{
+			if (*p != '-')
+			{
+				vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+					"dynamic_clip_apply_mapping_string_clip: expected a delimiter (-) following the clip offset");
+				return VOD_BAD_REQUEST;
+			}
+
+			p++;			// skip the -
+		}
+
+		// validate the ofset
+		if (i > 0)
+		{
+			if (offset <= last_offset)
+			{
+				vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+					"dynamic_clip_apply_mapping_string_clip: current offset %uD is smaller than previous offset %uD", 
+					offset, last_offset);
+				return VOD_BAD_REQUEST;
+			}
+
+			if (offset <= range_start)
+			{
+				vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+					"dynamic_clip_apply_mapping_string_clip: current offset %uD is smaller than range start %uL",
+					offset, range_start);
+				return VOD_BAD_REQUEST;
+			}
+		}
+
+		if (range_end <= offset)
+		{
+			vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+				"dynamic_clip_apply_mapping_string_clip: current offset %uD greater than range end %uL",
+				offset, range_end);
+			return VOD_BAD_REQUEST;
+		}
+
+		// calculate the range
+		range->start = 0;
+		range->timescale = 1000;
+
+		if (i == 0)
+		{
+			if (range_start > offset)
+			{
+				range->start = range_start - offset;
+			}
+		}
+		else
+		{
+			range[-1].end = offset - last_offset;
+		}
+
+		if (i + 1 == source_count)
+		{
+			range->end = range_end - offset;
+		}
+
+		// initialize the source
+		cur_source->next = sources_list_head;
+		sources_list_head = cur_source;
+
+		cur_source->base.type = MEDIA_CLIP_SOURCE;
+
+		cur_source->tracks_mask[MEDIA_TYPE_AUDIO] = 0xffffffff;
+		cur_source->tracks_mask[MEDIA_TYPE_VIDEO] = 0xffffffff;
+		cur_source->sequence = clip->sequence;
+		cur_source->range = range;
+		cur_source->sequence_offset = clip->sequence_offset + offset;
+		cur_source->stripped_uri = cur_source->mapped_uri = clip_id;
+		cur_source->clip_to = range->end;
+
+		vod_log_debug1(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
+			"dynamic_clip_apply_mapping_string_clip: parsed clip source - clipId=%V", &clip_id);
+
+		*cur_source_ptr++ = &cur_source->base;
+		cur_source++;
+		range++;
+
+		last_offset = offset;
+	}
+
+	media_set->mapped_sources_head = sources_list_head;
+
+	// replace the dynamic clip with a concat filter
+	clip->base.type = MEDIA_CLIP_CONCAT;
+	clip->base.source_count = source_count;
+
+	*cur = p;
+
+	return VOD_OK;
+}
+
+vod_status_t
+dynamic_clip_apply_mapping_string(
+	request_context_t* request_context,
+	media_set_t* media_set,
+	vod_str_t* mapping)
+{
+	media_clip_dynamic_t** prev;
+	media_clip_dynamic_t* cur;
+	vod_str_t clip_id;
+	vod_status_t rc;
+	uint32_t source_count;
+	u_char* end;
+	u_char* p;
+
+	// check for empty mapping
+	if (mapping->len == dynamic_clip_no_mapping.len &&
+		vod_memcmp(mapping->data, dynamic_clip_no_mapping.data, dynamic_clip_no_mapping.len) == 0)
+	{
+		return VOD_OK;
+	}
+
+	p = mapping->data;
+	end = mapping->data + mapping->len;
+
+	while (p < end)
+	{
+		// get the dynamic clip id
+		rc = dynamic_clip_extract_token(request_context, &p, end, &clip_id);
+		if (rc != VOD_OK)
+		{
+			return rc;
+		}
+
+		// get the source count
+		p = parse_utils_extract_uint32_token(p, end, &source_count);
+		if (source_count <= 0 || source_count > MAX_DYNAMIC_CLIP_SOURCE_COUNT)
+		{
+			vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+				"dynamic_clip_apply_mapping_string: invalid dynamic clip source count %uD",
+				source_count);
+			return VOD_BAD_REQUEST;
+		}
+
+		if (p >= end || *p != '-')
+		{
+			vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+				"dynamic_clip_apply_mapping_string: expected a delimiter (-) following the source count");
+			return VOD_BAD_REQUEST;
+		}
+		p++;		// skip the -
+
+		// look up the dynamic clip
+		for (prev = &media_set->dynamic_clips_head; ; prev = &cur->next)
+		{
+			cur = *prev;
+			if (cur == NULL)
+			{
+				vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+					"dynamic_clip_apply_mapping_string: dynamic clip \"%V\" not found", &clip_id);
+				return VOD_BAD_REQUEST;
+			}
+
+			if (cur->id.len == clip_id.len &&
+				vod_memcmp(cur->id.data, clip_id.data, clip_id.len) == 0)
+			{
+				break;
+			}
+		}
+
+		// apply the mapping
+		rc = dynamic_clip_apply_mapping_string_clip(request_context, media_set, cur, source_count, &p, end);
+		if (rc != VOD_OK)
+		{
+			return rc;
+		}
+
+		// remove the dynamic clip from the list
+		*prev = cur->next;
+	}
+
+	return VOD_OK;
+}

--- a/vod/filters/dynamic_clip.c
+++ b/vod/filters/dynamic_clip.c
@@ -280,7 +280,7 @@ dynamic_clip_apply_mapping_string_clip(
 	media_range_t* range;
 	media_clip_t** cur_source_ptr;
 	vod_str_t clip_id;
-	uint32_t last_offset;
+	uint32_t last_offset = 0;
 	uint32_t offset;
 	u_char* p = *cur;
 	uint64_t range_start;

--- a/vod/filters/dynamic_clip.c
+++ b/vod/filters/dynamic_clip.c
@@ -3,9 +3,9 @@
 #include "../media_set_parser.h"
 #include "../parse_utils.h"
 
+// constants
 #define MAX_DYNAMIC_CLIP_SOURCE_COUNT (128)
 
-// constants
 static json_object_value_def_t dynamic_clip_params[] = {
 	{ vod_string("id"), VOD_JSON_STRING, offsetof(media_clip_dynamic_t, id), media_set_parse_null_term_string },
 	{ vod_null_string, 0, 0, NULL }

--- a/vod/filters/dynamic_clip.h
+++ b/vod/filters/dynamic_clip.h
@@ -1,0 +1,49 @@
+#ifndef __DYNAMIC_CLIP_H__
+#define __DYNAMIC_CLIP_H__
+
+// includes
+#include "../json_parser.h"
+#include "../media_set.h"
+
+// typedefs
+struct media_clip_dynamic_s;
+typedef struct media_clip_dynamic_s media_clip_dynamic_t;
+
+// typedefs
+struct media_clip_dynamic_s {
+	media_clip_t base;
+	vod_str_t id;
+	struct media_sequence_s* sequence;
+	media_range_t* range;
+	int64_t sequence_offset;
+	uint32_t duration;
+	media_clip_dynamic_t* next;
+};
+
+// functions
+vod_status_t dynamic_clip_parse(
+	void* context,
+	vod_json_value_t* element,
+	void** result);
+
+vod_status_t dynamic_clip_parser_init(
+	vod_pool_t* pool,
+	vod_pool_t* temp_pool);
+
+vod_status_t dynamic_clip_apply_mapping_json(
+	media_clip_dynamic_t* clip,
+	request_context_t* request_context,
+	u_char* mapping,
+	media_set_t* media_set);
+
+vod_status_t dynamic_clip_get_mapping_string(
+	request_context_t* request_context,
+	media_clip_dynamic_t* dynamic_clips_head,
+	vod_str_t* result);
+
+vod_status_t dynamic_clip_apply_mapping_string(
+	request_context_t* request_context,
+	media_set_t* media_set,
+	vod_str_t* mapping);
+
+#endif // __DYNAMIC_CLIP_H__

--- a/vod/filters/filter.c
+++ b/vod/filters/filter.c
@@ -1,7 +1,7 @@
 #include "filter.h"
 #include "audio_filter.h"
 #include "rate_filter.h"
-#include "concat_filter.h"
+#include "concat_clip.h"
 #include "../media_set.h"
 
 // typedefs
@@ -48,7 +48,7 @@ filter_get_clip_track_count(media_clip_t* clip, uint32_t* track_count)
 	}
 
 	// recursively count child sources
-	if (clip->type == MEDIA_CLIP_CONCAT_FILTER)
+	if (clip->type == MEDIA_CLIP_CONCAT)
 	{
 		sources_end = clip->sources + 1;
 	}
@@ -184,9 +184,9 @@ filter_scale_video_tracks(filters_init_state_t* state, media_clip_t* clip, uint3
 	default:;
 	}
 
-	if (clip->type == MEDIA_CLIP_CONCAT_FILTER && clip->source_count > 1)
+	if (clip->type == MEDIA_CLIP_CONCAT && clip->source_count > 1)
 	{
-		rc = concat_filter_concat(state->request_context, clip);
+		rc = concat_clip_concat(state->request_context, clip);
 		if (rc != VOD_OK)
 		{
 			return rc;

--- a/vod/hds/hds_fragment.c
+++ b/vod/hds/hds_fragment.c
@@ -100,7 +100,7 @@ typedef struct {
 	uint32_t index;
 	uint32_t tag_size;
 
-	uint64_t clip_start_time;
+	int64_t clip_start_time;
 	uint64_t first_frame_time_offset;
 	uint64_t next_frame_time_offset;
 	uint64_t next_frame_dts;

--- a/vod/hls/hls_muxer.h
+++ b/vod/hls/hls_muxer.h
@@ -33,7 +33,7 @@ typedef struct {
 	input_frame_t* cur_frame;
 
 	// time offsets
-	uint64_t clip_start_time;
+	int64_t clip_start_time;
 	uint64_t first_frame_time_offset;
 	uint64_t next_frame_time_offset;
 	uint64_t next_frame_dts;

--- a/vod/manifest_utils.c
+++ b/vod/manifest_utils.c
@@ -1,0 +1,124 @@
+#include "manifest_utils.h"
+
+vod_status_t
+manifest_utils_build_request_params_string(
+	request_context_t* request_context, 
+	uint32_t* has_tracks,
+	uint32_t segment_index,
+	uint32_t sequence_index,
+	uint32_t* tracks_mask,
+	vod_str_t* result)
+{
+	u_char* p;
+	size_t result_size;
+	uint32_t i;
+
+	result_size = 0;
+	
+	// segment index
+	if (segment_index != INVALID_SEGMENT_INDEX)
+	{
+		result_size += 1 + vod_get_int_print_len(segment_index + 1);
+	}
+	
+	// sequence index
+	if (sequence_index != INVALID_SEQUENCE_INDEX)
+	{
+		result_size += sizeof("-f") - 1 + vod_get_int_print_len(sequence_index + 1);
+	}
+
+	// video tracks
+	if (tracks_mask[MEDIA_TYPE_VIDEO] == 0xffffffff)
+	{
+		result_size += sizeof("-v0") - 1;
+	}
+	else
+	{
+		result_size += vod_get_number_of_set_bits(tracks_mask[MEDIA_TYPE_VIDEO]) * (sizeof("-v32") - 1);
+	}
+	
+	// audio tracks
+	if (tracks_mask[MEDIA_TYPE_AUDIO] == 0xffffffff)
+	{
+		result_size += sizeof("-a0") - 1;
+	}
+	else
+	{
+		result_size += vod_get_number_of_set_bits(tracks_mask[MEDIA_TYPE_AUDIO]) * (sizeof("-a32") - 1);
+	}
+	
+	p = vod_alloc(request_context->pool, result_size + 1);
+	if (p == NULL)
+	{
+		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
+			"manifest_utils_build_request_params_string: vod_alloc failed");
+		return VOD_ALLOC_FAILED;
+	}
+	result->data = p;
+
+	// segment index
+	if (segment_index != INVALID_SEGMENT_INDEX)
+	{
+		p = vod_sprintf(p, "-%uD", segment_index + 1);
+	}
+	
+	// sequence index
+	if (sequence_index != INVALID_SEQUENCE_INDEX)
+	{
+		p = vod_sprintf(p, "-f%uD", sequence_index + 1);
+	}
+
+	// video tracks
+	if (has_tracks[MEDIA_TYPE_VIDEO])
+	{
+		if (tracks_mask[MEDIA_TYPE_VIDEO] == 0xffffffff)
+		{
+			p = vod_copy(p, "-v0", sizeof("-v0") - 1);
+		}
+		else
+		{
+			for (i = 0; i < 32; i++)
+			{
+				if ((tracks_mask[MEDIA_TYPE_VIDEO] & (1 << i)) == 0)
+				{
+					continue;
+				}
+
+				p = vod_sprintf(p, "-v%uD", i + 1);
+			}
+		}
+	}
+	
+	// audio tracks
+	if (has_tracks[MEDIA_TYPE_AUDIO])
+	{
+		if (tracks_mask[MEDIA_TYPE_AUDIO] == 0xffffffff)
+		{
+			p = vod_copy(p, "-a0", sizeof("-a0") - 1);
+		}
+		else
+		{
+			for (i = 0; i < 32; i++)
+			{
+				if ((tracks_mask[MEDIA_TYPE_AUDIO] & (1 << i)) == 0)
+				{
+					continue;
+				}
+
+				p = vod_sprintf(p, "-a%uD", i + 1);
+			}
+		}
+	}
+	
+	result->len = p - result->data;
+
+	if (result->len > result_size)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"manifest_utils_build_request_params_string: result length %uz exceeded allocated length %uz", 
+			result->len, result_size);
+		return VOD_UNEXPECTED;
+	}
+	
+	return VOD_OK;
+}

--- a/vod/manifest_utils.h
+++ b/vod/manifest_utils.h
@@ -1,0 +1,16 @@
+#ifndef __MANIFEST_UTILS_H__
+#define __MANIFEST_UTILS_H__
+
+// includes
+#include "media_set.h"
+
+// functions
+vod_status_t manifest_utils_build_request_params_string(
+	request_context_t* request_context,
+	uint32_t* has_tracks,
+	uint32_t segment_index,
+	uint32_t sequence_index,
+	uint32_t* tracks_mask,
+	vod_str_t* result);
+
+#endif //__MANIFEST_UTILS_H__

--- a/vod/media_clip.h
+++ b/vod/media_clip.h
@@ -17,7 +17,8 @@ typedef enum {
 	MEDIA_CLIP_RATE_FILTER,
 	MEDIA_CLIP_MIX_FILTER,
 	MEDIA_CLIP_GAIN_FILTER,
-	MEDIA_CLIP_CONCAT_FILTER,
+	MEDIA_CLIP_CONCAT,
+	MEDIA_CLIP_DYNAMIC,
 } media_clip_type_t;
 
 typedef struct media_clip_s {
@@ -29,6 +30,9 @@ typedef struct media_clip_s {
 	uint32_t id;
 } media_clip_t;
 
+struct media_clip_source_s;
+typedef struct media_clip_source_s media_clip_source_t;
+
 struct media_clip_source_s {
 	// input params
 	media_clip_t base;
@@ -36,7 +40,7 @@ struct media_clip_source_s {
 	uint32_t clip_to;
 	uint32_t clip_from;
 	uint32_t tracks_mask[MEDIA_TYPE_COUNT];
-	uint64_t sequence_offset;
+	int64_t sequence_offset;
 	u_char* encryption_key;
 
 	// derived params
@@ -49,8 +53,7 @@ struct media_clip_source_s {
 	media_range_t* range;
 	media_track_array_t track_array;
 	struct media_sequence_s* sequence;
+	media_clip_source_t* next;
 };
-
-typedef struct media_clip_source_s media_clip_source_t;
 
 #endif //__MEDIA_CLIP_H__

--- a/vod/media_format.h
+++ b/vod/media_format.h
@@ -93,7 +93,7 @@ typedef struct {
 
 typedef struct {
 	uint32_t* required_tracks_mask;
-	uint64_t clip_start_time;
+	int64_t clip_start_time;
 	uint32_t clip_from;
 	uint32_t clip_to;
 	media_range_t* range;
@@ -193,7 +193,7 @@ typedef struct {
 	uint64_t total_frames_duration;
 	uint32_t first_frame_index;
 	uint64_t first_frame_time_offset;
-	uint64_t clip_start_time;
+	int64_t clip_start_time;
 	int32_t clip_from_frame_offset;
 	raw_atom_t raw_atoms[RTA_COUNT];		// mp4 only
 	void* source_clip;

--- a/vod/media_set.h
+++ b/vod/media_set.h
@@ -80,8 +80,9 @@ typedef struct {
 	media_sequence_t* sequences;			// [sequence_count]
 	media_sequence_t* sequences_end;
 	bool_t has_multi_sequences;
-	media_clip_source_t** sources;
-	media_clip_source_t** sources_end;
+	media_clip_source_t* sources_head;
+	media_clip_source_t* mapped_sources_head;
+	struct media_clip_dynamic_s* dynamic_clips_head;
 	bool_t use_discontinuity;
 	uint32_t initial_segment_index;			// the index of the first segment in the playlist
 	uint32_t initial_clip_segment_index;	// the index of the first segment of the first playlist clip (can be less than initial_segment_index when the beginning of the clip is outside the live window)

--- a/vod/media_set_parser.h
+++ b/vod/media_set_parser.h
@@ -9,9 +9,11 @@ typedef struct {
 	request_context_t* request_context;
 	media_sequence_t* sequence;
 	media_range_t* range;
-	uint64_t sequence_offset;
+	int64_t sequence_offset;
 	uint32_t duration;
-	vod_array_t sources;
+	media_clip_source_t* sources_head;
+	media_clip_source_t* mapped_sources_head;
+	struct media_clip_dynamic_s* dynamic_clips_head;
 } media_filter_parse_context_t;
 
 // main functions
@@ -28,7 +30,17 @@ vod_status_t media_set_parse_json(
 	bool_t parse_all_clips,
 	media_set_t* result);
 
+vod_status_t media_set_map_source(
+	request_context_t* request_context,
+	u_char* string,
+	media_clip_source_t* source);
+
 // filter utility functions
+vod_status_t media_set_parse_null_term_string(
+	void* ctx, 
+	vod_json_value_t* value, 
+	void* dest);
+
 vod_status_t media_set_parse_filter_sources(
 	void* ctx,
 	vod_json_value_t* value,


### PR DESCRIPTION
add the ability to map clips dynamically, including redirection of segment requests so that the actual video content could be cached per ad video instead of per user