### PR TITLE
min frame duration only needed for video

### DIFF
--- a/ngx_http_vod_utils.c
+++ b/ngx_http_vod_utils.c
@@ -342,7 +342,6 @@ ngx_http_vod_range_parse(ngx_str_t* range, off_t content_length, off_t* out_star
 
     if (end >= content_length) {
         end = content_length;
-
     } else {
         end++;
     }

--- a/vod/filters/audio_filter.c
+++ b/vod/filters/audio_filter.c
@@ -936,18 +936,10 @@ audio_filter_update_track(audio_filter_state_t* state)
 	output->frames.frames_source = &frames_source_memory;
 
 	// calculate the total frames size and duration
-	output->media_info.min_frame_duration = 0;
-	
 	for (cur_frame = output->frames.first_frame; cur_frame < last_frame; cur_frame++)
 	{
 		output->total_frames_size += cur_frame->size;
 		output->total_frames_duration += cur_frame->duration;
-		
-		if (cur_frame->duration != 0 && 
-			(output->media_info.min_frame_duration == 0 || cur_frame->duration < output->media_info.min_frame_duration))
-		{
-			output->media_info.min_frame_duration = cur_frame->duration;
-		}
 	}
 	
 	// update media info

--- a/vod/media_format.h
+++ b/vod/media_format.h
@@ -133,7 +133,7 @@ typedef struct media_info_s {
 	uint64_t duration;
 	uint32_t duration_millis;
 	uint32_t bitrate;
-	uint32_t min_frame_duration;
+	uint32_t min_frame_duration;	// valid only for video
 	uint32_t codec_id;
 	vod_str_t codec_name;
 	vod_str_t extra_data;


### PR DESCRIPTION
also, in case the request is a range request, and the request range is contained in the header buffer, no need to process any frames