### PR TITLE
optimize frame reads

### DIFF
--- a/vod/filters/audio_filter.c
+++ b/vod/filters/audio_filter.c
@@ -1308,7 +1308,8 @@ audio_filter_process(void* context)
 			// start the frame
 			rc = source->cur_frame_part.frames_source->start_frame(
 				source->cur_frame_part.frames_source_context, 
-				source->cur_frame);
+				source->cur_frame,
+				ULLONG_MAX);
 			if (rc != VOD_OK)
 			{
 				return rc;

--- a/vod/hls/hls_muxer.h
+++ b/vod/hls/hls_muxer.h
@@ -34,6 +34,7 @@ typedef struct {
 	frame_list_part_t* first_frame_part;
 	frame_list_part_t cur_frame_part;
 	input_frame_t* cur_frame;
+	media_clip_source_t* source;
 
 	// time offsets
 	uint64_t first_frame_time_offset;

--- a/vod/input/frames_source.h
+++ b/vod/input/frames_source.h
@@ -9,7 +9,7 @@ struct input_frame_s;
 
 typedef struct {
 	void(*set_cache_slot_id)(void* context, int cache_slot_id);
-	vod_status_t(*start_frame)(void* context, struct input_frame_s* frame);
+	vod_status_t(*start_frame)(void* context, struct input_frame_s* frame, uint64_t min_offset);
 	vod_status_t(*read)(void* context, u_char** buffer, uint32_t* size, bool_t* frame_done);
 	void(*disable_buffer_reuse)(void* context);
 } frames_source_t;

--- a/vod/input/frames_source_cache.h
+++ b/vod/input/frames_source_cache.h
@@ -5,6 +5,16 @@
 #include "frames_source.h"
 #include "read_cache.h"
 
+// macros
+#define get_frame_part_source_clip(part) 	\
+	(part.frames_source == &frames_source_cache ? ((frames_source_cache_state_t*)part.frames_source_context)->req.source : NULL)
+
+// typedefs
+typedef struct {
+	read_cache_state_t* read_cache_state;
+	read_cache_request_t req;
+} frames_source_cache_state_t;
+
 // globals
 extern frames_source_t frames_source_cache;
 
@@ -13,6 +23,7 @@ vod_status_t frames_source_cache_init(
 	request_context_t* request_context,
 	read_cache_state_t* read_cache_state,
 	void* source,
+	int cache_slot_id,
 	void** result);
 
 #endif //__FRAMES_SOURCE_CACHE_H__

--- a/vod/input/frames_source_memory.c
+++ b/vod/input/frames_source_memory.c
@@ -33,7 +33,7 @@ frames_source_memory_set_cache_slot_id(void* ctx, int cache_slot_id)
 }
 
 static vod_status_t
-frames_source_memory_start_frame(void* ctx, input_frame_t* frame)
+frames_source_memory_start_frame(void* ctx, input_frame_t* frame, uint64_t min_offset)
 {
 	frames_source_memory_state_t* state = ctx;
 

--- a/vod/input/read_cache.c
+++ b/vod/input/read_cache.c
@@ -1,4 +1,5 @@
 #include "read_cache.h"
+#include "../media_clip.h"
 
 #define MIN_BUFFER_COUNT (2)
 
@@ -48,13 +49,16 @@ read_cache_allocate_buffer_slots(read_cache_state_t* state, size_t buffer_count)
 bool_t 
 read_cache_get_from_cache(
 	read_cache_state_t* state, 
-	int cache_slot_id, 
-	void* source, 
-	uint64_t offset, 
-	u_char** buffer, 
+	read_cache_request_t* request,
+	u_char** buffer,
 	uint32_t* size)
 {
+	media_clip_source_t* source = request->source;
+	cache_buffer_t* target_buffer;
 	cache_buffer_t* cur_buffer;
+	uint32_t read_size;
+	uint64_t offset = request->cur_offset;
+	size_t alignment;
 
 	// check whether we already have the requested offset
 	for (cur_buffer = state->buffers; cur_buffer < state->buffers_end; cur_buffer++)
@@ -69,10 +73,45 @@ read_cache_get_from_cache(
 	}
 
 	// don't have the offset in cache
-	cache_slot_id %= state->buffer_count;
-	state->target_buffer = &state->buffers[cache_slot_id];
-	state->target_buffer->source = source;
-	state->target_buffer->start_offset = (offset & ~(state->alignment - 1));
+	alignment = state->alignment - 1;
+	target_buffer = &state->buffers[request->cache_slot_id % state->buffer_count];
+
+	// start reading from the min offset, if that would contain the whole frame
+	// Note: this condition is intended to optimize the case in which the frame order 
+	//		in the output segment is <video1><audio1> while on disk it's <audio1><video1>. 
+	//		in this case it would be better to start reading from the beginning, even 
+	//		though the first frame that is requested is the second one
+	if (request->min_offset < offset && 
+		request->end_offset < (request->min_offset & ~alignment) + state->buffer_size)
+	{
+		offset = request->min_offset;
+	}
+	offset &= ~alignment;
+
+	// calculate the read size
+	read_size = state->buffer_size;
+
+	// don't read anything that is already in the cache
+	for (cur_buffer = state->buffers; cur_buffer < state->buffers_end; cur_buffer++)
+	{
+		if (cur_buffer != target_buffer &&
+			cur_buffer->source == source &&
+			cur_buffer->start_offset > offset)
+		{
+			read_size = vod_min(read_size, cur_buffer->start_offset - offset);
+		}
+	}
+
+	// don't read past the max required offset
+	if (offset + read_size > source->last_offset)
+	{
+		read_size = ((source->last_offset + alignment) & ~alignment) - offset;
+	}
+
+	target_buffer->source = source;
+	target_buffer->start_offset = offset;
+	target_buffer->buffer_size = read_size;
+	state->target_buffer = target_buffer;
 
 	return FALSE;
 }
@@ -86,32 +125,15 @@ read_cache_disable_buffer_reuse(read_cache_state_t* state)
 void 
 read_cache_get_read_buffer(
 	read_cache_state_t* state, 
-	void** source, 
-	uint64_t* out_offset, 
-	u_char** buffer, 
-	uint32_t* size)
+	read_cache_get_read_buffer_t* result)
 {
 	cache_buffer_t* target_buffer = state->target_buffer;
-	cache_buffer_t* cur_buffer;
-	uint32_t read_size;
-	
-	// make sure we don't read anything we already have in cache
-	read_size = state->buffer_size;
-	for (cur_buffer = state->buffers; cur_buffer < state->buffers_end; cur_buffer++)
-	{
-		if (cur_buffer != target_buffer && 
-			cur_buffer->source == target_buffer->source &&
-			cur_buffer->start_offset > target_buffer->start_offset)
-		{
-			read_size = vod_min(read_size, cur_buffer->start_offset - target_buffer->start_offset);
-		}
-	}
-	
+		
 	// return the target buffer pointer and size
-	*source = target_buffer->source;
-	*out_offset = target_buffer->start_offset;
-	*buffer = state->reuse_buffers ? target_buffer->buffer_start : NULL;
-	*size = read_size;
+	result->source = target_buffer->source;
+	result->offset = target_buffer->start_offset;
+	result->buffer = state->reuse_buffers ? target_buffer->buffer_start : NULL;
+	result->size = target_buffer->buffer_size;
 }
 
 void 

--- a/vod/input/read_cache.h
+++ b/vod/input/read_cache.h
@@ -5,6 +5,8 @@
 #include "../common.h"
 
 // typedefs
+struct media_clip_source_s;
+
 typedef struct {
 	u_char* buffer_start;
 	u_char* buffer_pos;
@@ -25,6 +27,21 @@ typedef struct {
 	bool_t reuse_buffers;
 } read_cache_state_t;
 
+typedef struct {
+	int cache_slot_id;
+	struct media_clip_source_s* source;
+	uint64_t cur_offset;
+	uint64_t end_offset;
+	uint64_t min_offset;
+} read_cache_request_t;
+
+typedef struct {
+	struct media_clip_source_s* source;
+	uint64_t offset;
+	u_char* buffer;
+	uint32_t size;
+} read_cache_get_read_buffer_t;
+
 // functions
 void read_cache_init(
 	read_cache_state_t* state, 
@@ -38,10 +55,8 @@ vod_status_t read_cache_allocate_buffer_slots(
 
 bool_t read_cache_get_from_cache(
 	read_cache_state_t* state, 
-	int cache_slot_id, 
-	void* source,
-	uint64_t offset, 
-	u_char** buffer, 
+	read_cache_request_t* request,
+	u_char** buffer,
 	uint32_t* size);
 
 void read_cache_disable_buffer_reuse(
@@ -49,10 +64,7 @@ void read_cache_disable_buffer_reuse(
 
 void read_cache_get_read_buffer(
 	read_cache_state_t* state, 
-	void** source,
-	uint64_t* out_offset,
-	u_char** buffer, 
-	uint32_t* size);
+	read_cache_get_read_buffer_t* result);
 	
 void read_cache_read_completed(read_cache_state_t* state, vod_buf_t* buf);
 

--- a/vod/media_clip.h
+++ b/vod/media_clip.h
@@ -54,6 +54,7 @@ struct media_clip_source_s {
 	media_track_array_t track_array;
 	struct media_sequence_s* sequence;
 	media_clip_source_t* next;
+	uint64_t last_offset;
 };
 
 #endif //__MEDIA_CLIP_H__

--- a/vod/mkv/mkv_builder.c
+++ b/vod/mkv/mkv_builder.c
@@ -652,7 +652,8 @@ mkv_builder_start_frame(mkv_fragment_writer_state_t* state)
 
 	rc = state->cur_frame_part.frames_source->start_frame(
 		state->cur_frame_part.frames_source_context,
-		state->cur_frame);
+		state->cur_frame, 
+		ULLONG_MAX);
 	if (rc != VOD_OK)
 	{
 		return rc;

--- a/vod/mp4/mp4_builder.c
+++ b/vod/mp4/mp4_builder.c
@@ -224,7 +224,7 @@ mp4_builder_frame_writer_process(fragment_writer_state_t* state)
 			return VOD_OK;
 		}
 
-		rc = state->cur_frame_part.frames_source->start_frame(state->cur_frame_part.frames_source_context, state->cur_frame);
+		rc = state->cur_frame_part.frames_source->start_frame(state->cur_frame_part.frames_source_context, state->cur_frame, ULLONG_MAX);
 		if (rc != VOD_OK)
 		{
 			return rc;
@@ -320,7 +320,7 @@ mp4_builder_frame_writer_process(fragment_writer_state_t* state)
 			}
 		}
 
-		rc = state->cur_frame_part.frames_source->start_frame(state->cur_frame_part.frames_source_context, state->cur_frame);
+		rc = state->cur_frame_part.frames_source->start_frame(state->cur_frame_part.frames_source_context, state->cur_frame, ULLONG_MAX);
 		if (rc != VOD_OK)
 		{
 			return rc;

--- a/vod/mp4/mp4_decrypt.c
+++ b/vod/mp4/mp4_decrypt.c
@@ -92,12 +92,12 @@ mp4_decrypt_set_cache_slot_id(void* ctx, int cache_slot_id)
 }
 
 static vod_status_t
-mp4_decrypt_start_frame(void* ctx, input_frame_t* frame)
+mp4_decrypt_start_frame(void* ctx, input_frame_t* frame, uint64_t min_offset)
 {
 	mp4_decrypt_state_t* state = ctx;
 	vod_status_t rc;
 
-	rc = state->frames_source->start_frame(state->frames_source_context, frame);
+	rc = state->frames_source->start_frame(state->frames_source_context, frame, min_offset);
 	if (rc != VOD_OK)
 	{
 		return rc;


### PR DESCRIPTION
- dont read past the end offset of the last frame
- in muxed output (hls/hds) try to load from offset that would satisfy both audio and video streams (instead of reading from the video frame only to find out later that we need to read few kbs before that offset to get the audio frame)
- bug fix - cache slot id was not initialized