### PR TITLE
clipping bug fixes

### DIFF
--- a/vod/mp4/mp4_parser.c
+++ b/vod/mp4/mp4_parser.c
@@ -909,7 +909,7 @@ mp4_parser_parse_stts_atom(atom_info_t* atom_info, frames_parse_context_t* conte
 				cur_frame->pts_delay = 0;
 			}
 
-			if (accum_duration >= clip_to)
+			if (frame_index >= key_frame_index || accum_duration >= clip_to)
 			{
 				break;
 			}
@@ -931,6 +931,10 @@ mp4_parser_parse_stts_atom(atom_info_t* atom_info, frames_parse_context_t* conte
 		if (key_frame_index != UINT_MAX)
 		{
 			range->end = accum_duration - clip_from_accum_duration;
+			if (clip_to < range->end)
+			{
+				range->end = clip_to;
+			}
 		}
 		else
 		{


### PR DESCRIPTION
- should not read the last stts entry when align to key frames is enabled and a key frame was reached. reading the last entry makes the module incorrectly set clip_to. this subsequently leads to a wrong duration being set in ngx_http_vod_update_track_timescale
- when adjusting the start/end ranges due to key frame alignment, must not cross the clip to