### PR TITLE
hide headers in upstream requests

### DIFF
--- a/ngx_child_http_request.h
+++ b/ngx_child_http_request.h
@@ -15,7 +15,7 @@ typedef struct {
 	off_t range_end;
 	ngx_table_elt_t extra_header;
 	ngx_flag_t proxy_range;
-	ngx_flag_t proxy_accept_encoding;
+	ngx_flag_t proxy_all_headers;
 } ngx_child_request_params_t;
 
 // functions
@@ -34,6 +34,6 @@ ngx_int_t ngx_child_request_start(
 	ngx_child_request_params_t* params,
 	ngx_buf_t* response_buffer);
 
-void ngx_child_request_init();
+ngx_int_t ngx_child_request_init(ngx_conf_t *cf);
 
 #endif // _NGX_CHILD_HTTP_REQUEST_INCLUDED_

--- a/ngx_http_vod_conf.c
+++ b/ngx_http_vod_conf.c
@@ -105,7 +105,13 @@ ngx_http_vod_init_parsers(ngx_conf_t *cf)
 		return NGX_ERROR;
 	}
 
-	ngx_child_request_init();
+	rc = ngx_child_request_init(cf);
+	if (rc != VOD_OK)
+	{
+		ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+			"failed to initialize hide headers hash %i", rc);
+		return NGX_ERROR;
+	}
 
 	return NGX_OK;
 }

--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -3009,7 +3009,7 @@ ngx_http_vod_dump_request_to_fallback(ngx_http_request_t *r)
 	child_params.extra_args = r->args;
 	child_params.extra_header = conf->proxy_header;
 	child_params.proxy_range = 1;
-	child_params.proxy_accept_encoding = 1;
+	child_params.proxy_all_headers = 1;
 
 	return ngx_child_request_start(
 		r,
@@ -3289,7 +3289,7 @@ ngx_http_vod_dump_http_request(ngx_http_vod_ctx_t *ctx)
 	child_params.base_uri = r->uri;
 	child_params.extra_args = ctx->upstream_extra_args;
 	child_params.proxy_range = 1;
-	child_params.proxy_accept_encoding = 1;
+	child_params.proxy_all_headers = 1;
 
 	return ngx_child_request_start(
 		r,


### PR DESCRIPTION
in all but dump requests, need to hide the following headers:
- Accept
- Accept-Charset
- Accept-Datetime
- Accept-Encoding
- Accept-Language
- If-Match
- If-Modified-Since
- If-None-Match
- If-Range
- If-Unmodified-Since

For example, Accept-Encoding can cause the upstream server to return gzip compressed response, If-Range can cause the upstream server to return the full response body instead of the requested range etc.