### PR TITLE
Optimize json

### DIFF
--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -1756,7 +1756,7 @@ ngx_http_vod_validate_streams(ngx_http_vod_ctx_t *ctx)
 		if (ctx->submodule_context.media_set.total_track_count != 1)
 		{
 			ngx_log_error(NGX_LOG_ERR, ctx->submodule_context.request_context.log, 0,
-				"ngx_http_vod_validate_streams: got %ui streams while only a single stream is supported",
+				"ngx_http_vod_validate_streams: got %uD streams while only a single stream is supported",
 				ctx->submodule_context.media_set.total_track_count);
 			return NGX_HTTP_BAD_REQUEST;
 		}

--- a/vod/filters/concat_clip.c
+++ b/vod/filters/concat_clip.c
@@ -43,7 +43,7 @@ concat_clip_parse(
 	void** result)
 {
 	media_filter_parse_context_t* context = ctx;
-	vod_json_array_part_t* first_part;
+	vod_json_array_part_t* first_part = NULL;
 	vod_json_array_part_t* part;
 	media_clip_source_t* sources_list_head;
 	media_clip_source_t* cur_source;
@@ -59,7 +59,7 @@ concat_clip_parse(
 	vod_str_t base_path;
 	vod_str_t dest_str;
 	u_char* end_pos;
-	int64_t* first_duration;
+	int64_t* first_duration = NULL;
 	int64_t* cur_duration;
 	int64_t cur_duration_value;
 	uint64_t start;
@@ -328,6 +328,7 @@ concat_clip_parse(
 	}
 
 	// decode the base path
+	base_path.len = 0;
 	if (params[CONCAT_PARAM_BASE_PATH] != NULL)
 	{
 		base_path.data = vod_alloc(context->request_context->pool, params[CONCAT_PARAM_BASE_PATH]->v.str.len);
@@ -338,7 +339,6 @@ concat_clip_parse(
 			return VOD_ALLOC_FAILED;
 		}
 
-		base_path.len = 0;
 		rc = vod_json_decode_string(&base_path, &params[CONCAT_PARAM_BASE_PATH]->v.str);
 		if (rc != VOD_JSON_OK)
 		{
@@ -346,11 +346,6 @@ concat_clip_parse(
 				"concat_clip_parse: vod_json_decode_string failed %i", rc);
 			return VOD_BAD_MAPPING;
 		}
-
-	}
-	else
-	{
-		base_path.len = 0;
 	}
 
 	// find the first path element

--- a/vod/filters/concat_clip.c
+++ b/vod/filters/concat_clip.c
@@ -39,31 +39,35 @@ static vod_hash_t concat_clip_hash;
 vod_status_t
 concat_clip_parse(
 	void* ctx,
-	vod_json_value_t* element,
+	vod_json_object_t* element,
 	void** result)
 {
 	media_filter_parse_context_t* context = ctx;
-	media_clip_concat_t* clip;
+	vod_json_array_part_t* first_part;
+	vod_json_array_part_t* part;
 	media_clip_source_t* sources_list_head;
 	media_clip_source_t* cur_source;
+	media_clip_source_t* sources_end;
 	media_clip_source_t* sources;
-	vod_json_value_t* array_elts;
+	media_clip_concat_t* clip;
 	vod_json_value_t* params[CONCAT_PARAM_COUNT];
-	vod_json_value_t* duration_elt = NULL;
+	vod_json_array_t* durations;
+	vod_json_array_t* paths;
+	media_range_t* range_cur;
 	media_range_t* range;
-	vod_array_t* paths;
-	vod_array_t* array;
 	vod_str_t* src_str;
-	u_char* end_pos;
 	vod_str_t base_path;
 	vod_str_t dest_str;
+	u_char* end_pos;
+	int64_t* first_duration;
+	int64_t* cur_duration;
+	int64_t cur_duration_value;
 	uint64_t start;
 	uint64_t end;
 	uint32_t tracks_mask[MEDIA_TYPE_COUNT];
 	uint32_t min_index;
 	uint32_t max_index;
 	uint32_t clip_count;
-	uint32_t cur_duration;
 	int32_t start_offset = 0;
 	int32_t next_offset;
 	int32_t offset;
@@ -98,6 +102,14 @@ concat_clip_parse(
 		return VOD_BAD_MAPPING;
 	}
 
+	if (paths->type != VOD_JSON_STRING)
+	{
+		vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
+			"concat_clip_parse: invalid type %d of \"paths\" elements, must be string",
+			paths->type);
+		return VOD_BAD_MAPPING;
+	}
+
 	if (params[CONCAT_PARAM_DURATIONS] == NULL)
 	{
 		vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
@@ -105,27 +117,47 @@ concat_clip_parse(
 		return VOD_BAD_MAPPING;
 	}
 
-	if (paths->nelts != params[CONCAT_PARAM_DURATIONS]->v.arr.nelts)
+	if (paths->count != params[CONCAT_PARAM_DURATIONS]->v.arr.count)
 	{
 		vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-			"concat_clip_parse: \"paths\" element count %ui different than \"durations\" element count %ui", 
-			paths->nelts,
-			params[CONCAT_PARAM_DURATIONS]->v.arr.nelts);
+			"concat_clip_parse: \"paths\" element count %uz different than \"durations\" element count %uz", 
+			paths->count,
+			params[CONCAT_PARAM_DURATIONS]->v.arr.count);
 		return VOD_BAD_MAPPING;
 	}
 
-	if (paths->nelts > MAX_CONCAT_ELEMENTS)
+	if (paths->count > MAX_CONCAT_ELEMENTS)
 	{
 		vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-			"concat_clip_parse: number of concat elements %ui too big",
-			paths->nelts);
+			"concat_clip_parse: number of concat elements %uz too big",
+			paths->count);
 		return VOD_BAD_MAPPING;
+	}
+
+	// initialize the tracks mask
+	if (params[CONCAT_PARAM_TRACKS] != NULL)
+	{
+		src_str = &params[CONCAT_PARAM_TRACKS]->v.str;
+		end_pos = src_str->data + src_str->len;
+		tracks_mask[MEDIA_TYPE_AUDIO] = 0;
+		tracks_mask[MEDIA_TYPE_VIDEO] = 0;
+		if (parse_utils_extract_track_tokens(src_str->data, end_pos, tracks_mask) != end_pos)
+		{
+			vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
+				"concat_clip_parse: failed to parse tracks specification");
+			return VOD_BAD_MAPPING;
+		}
+	}
+	else
+	{
+		tracks_mask[MEDIA_TYPE_AUDIO] = 0xffffffff;
+		tracks_mask[MEDIA_TYPE_VIDEO] = 0xffffffff;
 	}
 
 	if (context->range == NULL)
 	{
 		// no range, just use the first clip
-		if (paths->nelts <= 0)
+		if (paths->count <= 0)
 		{
 			vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
 				"concat_clip_parse: \"paths\" array is empty");
@@ -133,18 +165,36 @@ concat_clip_parse(
 		}
 
 		min_index = 0;
-		max_index = 0;
 		clip_count = 1;
 		range = NULL;
+
+		// allocate the source
+		sources = vod_alloc(context->request_context->pool, sizeof(sources[0]));
+		if (sources == NULL)
+		{
+			vod_log_debug0(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
+				"concat_clip_parse: vod_alloc failed (1)");
+			return VOD_ALLOC_FAILED;
+		}
+		sources_end = sources + 1;
+		vod_memzero(sources, sizeof(sources[0]));
+		sources->clip_to = context->duration;
 	}
 	else
 	{
-		array = &params[CONCAT_PARAM_DURATIONS]->v.arr;
-		array_elts = array->elts;
+		durations = &params[CONCAT_PARAM_DURATIONS]->v.arr;
+		if (durations->type != VOD_JSON_INT)
+		{
+			vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
+				"concat_clip_parse: invalid type %d of \"durations\" element, must be int",
+				durations->type);
+			return VOD_BAD_MAPPING;
+		}
 
 		start = context->range->start;
 		end = context->range->end;
 
+		// parse the offset
 		if (params[CONCAT_PARAM_OFFSET] != NULL)
 		{
 			if (params[CONCAT_PARAM_OFFSET]->v.num.nom < INT_MIN)
@@ -168,30 +218,42 @@ concat_clip_parse(
 		}
 
 		min_index = UINT_MAX;
-		max_index = array->nelts - 1;
-		for (i = 0; i < array->nelts; i++, offset = next_offset)
+		max_index = durations->count - 1;
+		part = &durations->part;
+		for (i = 0, cur_duration = part->first;
+			; 
+			i++, cur_duration++, offset = next_offset)
 		{
+			if ((void*)cur_duration >= part->last)
+			{
+				if (part->next == NULL)
+				{
+					break;
+				}
+
+				part = part->next;
+				cur_duration = part->first;
+			}
+
 			// validate the current duration element
-			if (array_elts[i].type != VOD_JSON_INT)
+			cur_duration_value = *cur_duration;
+			if (cur_duration_value < 0)
 			{
 				vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-					"concat_clip_parse: invalid type %d of \"durations\" element, must be int", 
-					array_elts[i].type);
+					"concat_clip_parse: negative duration value");
 				return VOD_BAD_MAPPING;
 			}
 
-			if (array_elts[i].v.num.nom > INT_MAX - vod_max(offset, 0))
+			if (cur_duration_value > INT_MAX - vod_max(offset, 0))
 			{
 				vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
 					"concat_clip_parse: duration value %uL too big",
-					array_elts[i].v.num.nom);
+					cur_duration_value);
 				return VOD_BAD_MAPPING;
 			}
 
-			cur_duration = array_elts[i].v.num.nom;
-
 			// update the min/max indexes
-			next_offset = offset + cur_duration;
+			next_offset = offset + cur_duration_value;
 			if (next_offset <= (int64_t)start)
 			{
 				continue;
@@ -201,6 +263,8 @@ concat_clip_parse(
 			{
 				min_index = i;
 				start_offset = offset;
+				first_part = part;
+				first_duration = cur_duration;
 			}
 
 			if (next_offset >= (int64_t)end)
@@ -218,22 +282,38 @@ concat_clip_parse(
 			return VOD_BAD_MAPPING;
 		}
 
-		// initialize the new range
+		// allocate the sources and ranges
 		clip_count = max_index - min_index + 1;
-
-		range = vod_alloc(context->request_context->pool, sizeof(range[0]) * clip_count);
-		if (range == NULL)
+		sources = vod_alloc(context->request_context->pool,
+			(sizeof(sources[0]) + sizeof(range[0])) * clip_count);
+		if (sources == NULL)
 		{
 			vod_log_debug0(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
-				"concat_clip_parse: vod_alloc failed (1)");
+				"concat_clip_parse: vod_alloc failed (2)");
 			return VOD_ALLOC_FAILED;
 		}
+		sources_end = sources + clip_count;
+		vod_memzero(sources, sizeof(sources[0]) * clip_count);
 
-		for (i = 0; i < clip_count; i++)
+		range = (void*)sources_end;
+
+		// initialize the ranges
+		part = first_part;
+		for (cur_source = sources, range_cur = range, cur_duration = first_duration;
+			cur_source < sources_end;
+			cur_source++, range_cur++, cur_duration++)
 		{
-			range[i].start = 0;
-			range[i].end = array_elts[i + min_index].v.num.nom;
-			range[i].timescale = 1000;
+			if ((void*)cur_duration >= part->last)
+			{
+				part = part->next;
+				cur_duration = part->first;
+			}
+
+			range_cur->start = 0;
+			range_cur->end = *cur_duration;
+			range_cur->timescale = 1000;
+
+			cur_source->clip_to = *cur_duration;
 		}
 
 		if ((int64_t)start > start_offset)
@@ -245,86 +325,65 @@ concat_clip_parse(
 		{
 			range[clip_count - 1].end = end - offset;
 		}
-
-		duration_elt = array_elts + min_index;
 	}
 
-	// initialize the tracks mask
-	if (params[CONCAT_PARAM_TRACKS] != NULL)
-	{
-		src_str = &params[CONCAT_PARAM_TRACKS]->v.str;
-		end_pos = src_str->data + src_str->len;
-		tracks_mask[MEDIA_TYPE_AUDIO] = 0;
-		tracks_mask[MEDIA_TYPE_VIDEO] = 0;
-		if (parse_utils_extract_track_tokens(src_str->data, end_pos, tracks_mask) != end_pos)
-		{
-			vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-				"concat_clip_parse: failed to parse tracks specification");
-			return VOD_BAD_MAPPING;
-		}
-	}
-	else
-	{
-		tracks_mask[MEDIA_TYPE_AUDIO] = 0xffffffff;
-		tracks_mask[MEDIA_TYPE_VIDEO] = 0xffffffff;
-	}
-
-	// get the base path
+	// decode the base path
 	if (params[CONCAT_PARAM_BASE_PATH] != NULL)
 	{
-		base_path = params[CONCAT_PARAM_BASE_PATH]->v.str;
+		base_path.data = vod_alloc(context->request_context->pool, params[CONCAT_PARAM_BASE_PATH]->v.str.len);
+		if (base_path.data == NULL)
+		{
+			vod_log_debug0(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
+				"concat_clip_parse: vod_alloc failed (3)");
+			return VOD_ALLOC_FAILED;
+		}
+
+		base_path.len = 0;
+		rc = vod_json_decode_string(&base_path, &params[CONCAT_PARAM_BASE_PATH]->v.str);
+		if (rc != VOD_JSON_OK)
+		{
+			vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
+				"concat_clip_parse: vod_json_decode_string failed %i", rc);
+			return VOD_BAD_MAPPING;
+		}
+
 	}
 	else
 	{
 		base_path.len = 0;
 	}
 
-	// allocate the sources and source pointers
-	sources = vod_alloc(context->request_context->pool, sizeof(sources[0]) * clip_count);
-	if (sources == NULL)
+	// find the first path element
+	i = min_index;
+	part = &paths->part;
+	while (i >= part->count)
 	{
-		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
-			"concat_clip_parse: vod_alloc failed (2)");
-		return VOD_ALLOC_FAILED;
+		i -= part->count;
+		part = part->next;
 	}
-	vod_memzero(sources, sizeof(sources[0]) * clip_count);
+	src_str = (vod_str_t*)part->first + i;
+
 	cur_source = sources;
-
 	offset = context->sequence_offset + start_offset;
-
-	array_elts = paths->elts;
-	for (i = min_index; i <= max_index; i++)
+	for (;;)
 	{
-		// decode the path
-		if (array_elts[i].type != VOD_JSON_STRING)
+		if ((void*)src_str >= part->last)
 		{
-			vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-				"concat_clip_parse: invalid type %d of \"paths\" element, must be string",
-				array_elts[i].type);
-			return VOD_BAD_MAPPING;
+			part = part->next;
+			src_str = part->first;
 		}
 
-		src_str = &array_elts[i].v.str;
-
+		// decode the path
 		dest_str.data = vod_alloc(context->request_context->pool, base_path.len + src_str->len + 1);
 		if (dest_str.data == NULL)
 		{
 			vod_log_debug0(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
-				"concat_clip_parse: vod_alloc failed (3)");
+				"concat_clip_parse: vod_alloc failed (4)");
 			return VOD_ALLOC_FAILED;
 		}
-		dest_str.len = 0;
 
-		if (base_path.len != 0)
-		{
-			rc = vod_json_decode_string(&dest_str, &base_path);
-			if (rc != VOD_JSON_OK)
-			{
-				vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-					"concat_clip_parse: vod_json_decode_string failed %i", rc);
-				return VOD_BAD_MAPPING;
-			}
-		}
+		vod_memcpy(dest_str.data, base_path.data, base_path.len);
+		dest_str.len = base_path.len;
 
 		rc = vod_json_decode_string(&dest_str, src_str);
 		if (rc != VOD_JSON_OK)
@@ -355,15 +414,12 @@ concat_clip_parse(
 			cur_source->tracks_mask[MEDIA_TYPE_VIDEO],
 			cur_source->tracks_mask[MEDIA_TYPE_AUDIO]);
 
-		if (range == NULL)
+		cur_source++;
+		if (cur_source >= sources_end)
 		{
-			cur_source->clip_to = context->duration;
 			break;
 		}
 
-		cur_source->clip_to = duration_elt->v.num.nom;
-		duration_elt++;
-		cur_source++;
 		offset += range->end;
 		range++;
 	}
@@ -380,7 +436,7 @@ concat_clip_parse(
 	if (clip == NULL)
 	{
 		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
-			"concat_clip_parse: vod_alloc failed (4)");
+			"concat_clip_parse: vod_alloc failed (5)");
 		return VOD_ALLOC_FAILED;
 	}
 

--- a/vod/filters/concat_clip.h
+++ b/vod/filters/concat_clip.h
@@ -8,7 +8,7 @@
 // functions
 vod_status_t concat_clip_parse(
 	void* context,
-	vod_json_value_t* element,
+	vod_json_object_t* element,
 	void** result);
 
 vod_status_t concat_clip_concat(

--- a/vod/filters/dynamic_clip.c
+++ b/vod/filters/dynamic_clip.c
@@ -18,7 +18,7 @@ static vod_hash_t dynamic_clip_hash;
 vod_status_t
 dynamic_clip_parse(
 	void* ctx,
-	vod_json_value_t* element,
+	vod_json_object_t* element,
 	void** result)
 {
 	media_filter_parse_context_t* context = ctx;
@@ -118,6 +118,13 @@ dynamic_clip_apply_mapping_json(
 		return VOD_BAD_MAPPING;
 	}
 
+	if (json.type != VOD_JSON_OBJECT)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"dynamic_clip_apply_mapping_json: invalid root element type %d expected object", json.type);
+		return VOD_BAD_MAPPING;
+	}
+
 	context.request_context = request_context;
 	context.sources_head = media_set->sources_head;
 	context.mapped_sources_head = media_set->mapped_sources_head;
@@ -126,7 +133,7 @@ dynamic_clip_apply_mapping_json(
 	context.duration = clip->duration;
 	context.range = clip->range;
 
-	rc = concat_clip_parse(&context, &json, (void**)&concat_clip);
+	rc = concat_clip_parse(&context, &json.v.obj, (void**)&concat_clip);
 	if (rc != VOD_OK)
 	{
 		vod_log_debug1(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,

--- a/vod/filters/dynamic_clip.h
+++ b/vod/filters/dynamic_clip.h
@@ -23,7 +23,7 @@ struct media_clip_dynamic_s {
 // functions
 vod_status_t dynamic_clip_parse(
 	void* context,
-	vod_json_value_t* element,
+	vod_json_object_t* element,
 	void** result);
 
 vod_status_t dynamic_clip_parser_init(

--- a/vod/filters/gain_filter.c
+++ b/vod/filters/gain_filter.c
@@ -68,7 +68,7 @@ static audio_filter_t gain_filter = {
 vod_status_t
 gain_filter_parse(
 	void* ctx,
-	vod_json_value_t* element,
+	vod_json_object_t* element,
 	void** result)
 {
 	media_filter_parse_context_t* context = ctx;
@@ -123,7 +123,7 @@ gain_filter_parse(
 
 	rc = media_set_parse_clip(
 		context,
-		source,
+		&source->v.obj,
 		&filter->base,
 		&filter->base.sources[0]);
 	if (rc != VOD_JSON_OK)

--- a/vod/filters/gain_filter.h
+++ b/vod/filters/gain_filter.h
@@ -7,7 +7,7 @@
 // functions
 vod_status_t gain_filter_parse(
 	void* context,
-	vod_json_value_t* element,
+	vod_json_object_t* element,
 	void** result);
 
 vod_status_t gain_filter_parser_init(

--- a/vod/filters/mix_filter.c
+++ b/vod/filters/mix_filter.c
@@ -65,7 +65,7 @@ static audio_filter_t mix_filter = {
 vod_status_t
 mix_filter_parse(
 	void* ctx,
-	vod_json_value_t* element,
+	vod_json_object_t* element,
 	void** result)
 {
 	media_filter_parse_context_t* context = ctx;

--- a/vod/filters/mix_filter.h
+++ b/vod/filters/mix_filter.h
@@ -7,7 +7,7 @@
 // functions
 vod_status_t mix_filter_parse(
 	void* context,
-	vod_json_value_t* element,
+	vod_json_object_t* element,
 	void** result);
 
 vod_status_t mix_filter_parser_init(

--- a/vod/filters/rate_filter.c
+++ b/vod/filters/rate_filter.c
@@ -114,7 +114,7 @@ static audio_filter_t rate_filter = {
 vod_status_t
 rate_filter_parse(
 	void* ctx,
-	vod_json_value_t* element,
+	vod_json_object_t* element,
 	void** result)
 {
 	media_filter_parse_context_t* context = ctx;
@@ -200,7 +200,7 @@ rate_filter_parse(
 
 	rc = media_set_parse_clip(
 		context, 
-		source, 
+		&source->v.obj, 
 		&filter->base,
 		&filter->base.sources[0]);
 	if (rc != VOD_JSON_OK)

--- a/vod/filters/rate_filter.h
+++ b/vod/filters/rate_filter.h
@@ -19,7 +19,7 @@ void rate_filter_scale_track_timestamps(
 
 vod_status_t rate_filter_parse(
 	void* context,
-	vod_json_value_t* element,
+	vod_json_object_t* element,
 	void** result);
 
 vod_status_t rate_filter_create_from_string(

--- a/vod/json_parser.h
+++ b/vod/json_parser.h
@@ -31,14 +31,29 @@ typedef struct {
 	uint64_t denom;
 } vod_json_fraction_t;
 
+typedef struct vod_json_array_part_s {
+	void* first;
+	void* last;
+	size_t count;
+	struct vod_json_array_part_s* next;
+} vod_json_array_part_t;
+
+typedef struct {
+	int type;
+	size_t count;
+	vod_json_array_part_t part;
+} vod_json_array_t;
+
+typedef vod_array_t vod_json_object_t;
+
 typedef struct {
 	int type;
 	union {
 		bool_t boolean;
 		vod_json_fraction_t num;
 		vod_str_t str;			// Note: the string is not unescaped (e.g. may contain \n, \t etc.)
-		vod_array_t arr;		// of vod_json_value_t
-		vod_array_t obj;		// of vod_json_key_value_t
+		vod_json_array_t arr;
+		vod_json_object_t obj;	// of vod_json_key_value_t
 	} v;
 } vod_json_value_t;
 
@@ -74,7 +89,7 @@ typedef struct {
 } json_object_key_def_t;
 
 void vod_json_get_object_values(
-	vod_json_value_t* object,
+	vod_json_object_t* object,
 	vod_hash_t* values_hash,
 	vod_json_value_t** result);
 
@@ -92,7 +107,7 @@ typedef struct {
 } json_object_value_def_t;
 
 vod_status_t vod_json_parse_object_values(
-	vod_json_value_t* object,
+	vod_json_object_t* object,
 	vod_hash_t* values_hash,
 	void* context,
 	void* result);
@@ -100,7 +115,7 @@ vod_status_t vod_json_parse_object_values(
 // union parsing
 typedef vod_status_t(*json_parser_union_type_parser_t)(
 	void* context,
-	vod_json_value_t* element,
+	vod_json_object_t* object,
 	void** dest);
 
 typedef struct {
@@ -110,7 +125,7 @@ typedef struct {
 
 vod_status_t vod_json_parse_union(
 	request_context_t* request_context,
-	vod_json_value_t* object,
+	vod_json_object_t* object,
 	vod_str_t* type_field,
 	vod_uint_t type_field_hash,
 	vod_hash_t* union_hash,

--- a/vod/media_set_parser.h
+++ b/vod/media_set_parser.h
@@ -48,7 +48,7 @@ vod_status_t media_set_parse_filter_sources(
 
 vod_status_t media_set_parse_clip(
 	void* ctx,
-	vod_json_value_t* element,
+	vod_json_object_t* element,
 	media_clip_t* parent,
 	media_clip_t** result);
 


### PR DESCRIPTION
- require uniform size across all array elements, and allocate the minimum size according to the element type (instead of vod_json_value_t)
- use an ngx_list_t inspired structure for holding the array elements, to avoid reallocs during parsing