### PR TITLE
add support key frame positions in mapping json

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,14 @@ Optional fields:
 * `label` - a friendly string that identifies the sequence. if a language is specified,
 	a default label will be automatically derived by it - e.g. if language is `ita`, 
 	by default `italiano` will be used as the label.
+* `keyFrameDurations` - array of integers, containing the durations of the video key frames
+	in the sequence. Supplying the key frame durations enables the module to both:
+	1. align the segments to key frames 
+	2. report the correct segment durations in the manifest - providing an alternative to setting
+		`vod_manifest_segment_durations_mode` to `accurate`, which is not supported for multi clip
+		media sets (for performance reasons).
+* `firstKeyFrameOffset` - integer, offset of the first video key frame in the sequence, 
+	measured in milliseconds relative to `firstClipTime`. Defaults to 0 if not supplied.
 
 #### Clip (abstract)
 

--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -986,6 +986,7 @@ ngx_http_vod_parse_metadata(
 	ngx_http_vod_ctx_t *ctx, 
 	ngx_flag_t fetched_from_cache)
 {
+	get_clip_ranges_params_t get_ranges_params;
 	media_parse_params_t parse_params;
 	const ngx_http_vod_request_t* request = ctx->request;
 	media_clip_source_t* cur_source = ctx->cur_source;
@@ -1143,15 +1144,18 @@ ngx_http_vod_parse_metadata(
 			// get the start/end offsets
 			duration_millis = rescale_time(ctx->base_metadata->duration * rate.denom, ctx->base_metadata->timescale * rate.nom, 1000);
 
+			get_ranges_params.request_context = &ctx->submodule_context.request_context,
+			get_ranges_params.conf = segmenter,
+			get_ranges_params.segment_index = ctx->submodule_context.request_params.segment_index,
+			get_ranges_params.clip_durations = &duration_millis,
+			get_ranges_params.total_clip_count = 1,
+			get_ranges_params.start_time = 0,
+			get_ranges_params.end_time = duration_millis,
+			get_ranges_params.last_segment_end = last_segment_end,
+			get_ranges_params.key_frame_durations = NULL;
+
 			rc = segmenter_get_start_end_ranges_no_discontinuity(
-				&ctx->submodule_context.request_context,
-				segmenter,
-				ctx->submodule_context.request_params.segment_index,
-				&duration_millis,
-				1,
-				0,
-				duration_millis,
-				last_segment_end,
+				&get_ranges_params,
 				&clip_ranges);
 			if (rc != VOD_OK)
 			{

--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -909,6 +909,8 @@ ngx_http_vod_parse_uri_path(
 		cur_sequence->id.len = 0;
 		cur_sequence->language = 0;
 		cur_sequence->label.len = 0;
+		cur_sequence->first_key_frame_offset = 0;
+		cur_sequence->key_frame_durations = NULL;
 
 		cur_source++;
 		cur_sequence++;

--- a/vod/common.h
+++ b/vod/common.h
@@ -264,6 +264,13 @@ enum {
 	VOD_ERROR_LAST,
 };
 
+typedef struct vod_array_part_s {
+	void* first;
+	void* last;
+	size_t count;
+	struct vod_array_part_s* next;
+} vod_array_part_t;
+
 typedef vod_status_t(*write_callback_t)(void* context, u_char* buffer, uint32_t size);
 
 typedef struct {

--- a/vod/filters/concat_clip.c
+++ b/vod/filters/concat_clip.c
@@ -43,8 +43,8 @@ concat_clip_parse(
 	void** result)
 {
 	media_filter_parse_context_t* context = ctx;
-	vod_json_array_part_t* first_part = NULL;
-	vod_json_array_part_t* part;
+	vod_array_part_t* first_part = NULL;
+	vod_array_part_t* part;
 	media_clip_source_t* sources_list_head;
 	media_clip_source_t* cur_source;
 	media_clip_source_t* sources_end;

--- a/vod/json_parser.c
+++ b/vod/json_parser.c
@@ -321,7 +321,7 @@ vod_json_parse_fraction(vod_json_parser_state_t* state, vod_json_fraction_t* res
 static vod_json_status_t
 vod_json_parse_array(vod_json_parser_state_t* state, vod_json_array_t* result)
 {
-	vod_json_array_part_t* part;
+	vod_array_part_t* part;
 	vod_json_type_t* type;
 	size_t initial_part_count;
 	size_t part_size;

--- a/vod/json_parser.h
+++ b/vod/json_parser.h
@@ -31,17 +31,10 @@ typedef struct {
 	uint64_t denom;
 } vod_json_fraction_t;
 
-typedef struct vod_json_array_part_s {
-	void* first;
-	void* last;
-	size_t count;
-	struct vod_json_array_part_s* next;
-} vod_json_array_part_t;
-
 typedef struct {
 	int type;
 	size_t count;
-	vod_json_array_part_t part;
+	vod_array_part_t part;
 } vod_json_array_t;
 
 typedef vod_array_t vod_json_object_t;

--- a/vod/media_format.h
+++ b/vod/media_format.h
@@ -16,6 +16,8 @@
 #define MAX_FRAME_SIZE (10 * 1024 * 1024)
 #define MAX_TRACK_COUNT (1024)
 #define MAX_DURATION_SEC (1000000)
+#define MAX_CLIP_DURATION (86400000)		// 1 day
+#define MAX_SEQUENCE_DURATION (864000000)		// 10 days
 
 // parse flags
 

--- a/vod/media_set.h
+++ b/vod/media_set.h
@@ -44,11 +44,14 @@ typedef struct {
 struct media_sequence_s {
 	// initialized during parsing
 	uint32_t index;
+	vod_array_part_t* unparsed_clips;
 	media_clip_t** clips;						// [clip_count]
 	vod_str_t stripped_uri;
 	vod_str_t id;
 	vod_str_t label;
 	language_id_t language;
+	int64_t first_key_frame_offset;
+	vod_array_part_t* key_frame_durations;
 
 	// initialized after mapping
 	vod_str_t mapped_uri;

--- a/vod/segmenter.h
+++ b/vod/segmenter.h
@@ -31,6 +31,21 @@ typedef struct {
 } segment_durations_t;
 
 typedef struct {
+	request_context_t* request_context;
+	segmenter_conf_t* conf;
+	uint32_t clip_index;
+	uint32_t segment_index;
+	uint32_t initial_segment_index;
+	uint32_t* clip_durations;
+	uint32_t total_clip_count;
+	uint64_t start_time;
+	uint64_t end_time;
+	uint64_t last_segment_end;
+	int64_t first_key_frame_offset;
+	vod_array_part_t* key_frame_durations;
+} get_clip_ranges_params_t;
+
+typedef struct {
 	uint32_t min_clip_index;
 	uint32_t max_clip_index;
 	uint64_t initial_sequence_offset;
@@ -118,25 +133,11 @@ vod_status_t segmenter_get_segment_index_discontinuity(
 
 // get start end ranges
 vod_status_t segmenter_get_start_end_ranges_no_discontinuity(
-	request_context_t* request_context,
-	segmenter_conf_t* conf,
-	uint32_t segment_index,
-	uint32_t* clip_durations,
-	uint32_t total_clip_count,
-	uint64_t start_time,
-	uint64_t end_time,
-	uint64_t last_segment_end,
+	get_clip_ranges_params_t* params,
 	get_clip_ranges_result_t* result);
 
 vod_status_t segmenter_get_start_end_ranges_discontinuity(
-	request_context_t* request_context,
-	segmenter_conf_t* conf,
-	uint32_t clip_index,
-	uint32_t segment_index,
-	uint32_t initial_segment_index,
-	uint32_t* clip_durations,
-	uint32_t total_clip_count,
-	uint64_t total_duration,
+	get_clip_ranges_params_t* params,
 	get_clip_ranges_result_t* result);
 
 #endif // __SEGMENTER_H__

--- a/vod/udrm.c
+++ b/vod/udrm.c
@@ -45,7 +45,7 @@ udrm_parse_response(
 	bool_t base64_decode_pssh,
 	void** output)
 {
-	vod_json_array_part_t* part;
+	vod_array_part_t* part;
 	vod_json_object_t* cur_input_pssh;
 	vod_json_object_t* element;
 	drm_system_info_t* cur_output_pssh;


### PR DESCRIPTION
make is possible to align the segments to keyframes while having accurate
segment durations in the manifest.