### PR TITLE
Fix build without OpenSSL EVP

### DIFF
--- a/vod/mp4/mp4_encrypt.c
+++ b/vod/mp4/mp4_encrypt.c
@@ -989,6 +989,7 @@ mp4_encrypt_video_get_fragment_writer(
 	request_context_t* request_context,
 	media_set_t* media_set,
 	uint32_t segment_index,
+	bool_t single_nalu_per_frame,
 	mp4_encrypt_video_build_fragment_header_t build_fragment_header,
 	segment_writer_t* segment_writer,
 	const u_char* iv, 


### PR DESCRIPTION
Due to the lack of parameter in the signature of stub function `mp4_encrypt_video_get_fragment_writer`, building of Nginx with nginx-vod-module failed in the absence of OpenSSL EVP library:
```
../nginx-vod-module/vod/mp4/mp4_encrypt.c:987:1: error: conflicting types for ‘mp4_encrypt_video_get_fragment_writer’
In file included from ../nginx-vod-module/vod/mp4/mp4_encrypt.c:1:0:
../nginx-vod-module/vod/mp4/mp4_encrypt.h:80:14: note: previous declaration of ‘mp4_encrypt_video_get_fragment_writer’ was here
make[1]: *** [objs/addon/mp4/mp4_encrypt.o] Error 1
```
This small pull request fixes that.