### PR TITLE
Timing bug fixes

### DIFF
--- a/test/compare_utils.py
+++ b/test/compare_utils.py
@@ -1,0 +1,42 @@
+import email.utils as eut
+import time
+
+INGORED_HEADERS = set([
+	'x-vod-me','x-vod-session',
+	'x-me', 'x-kaltura-session', 
+	'x-varnish', 
+])
+
+IGNORE_HEADER_VALUES = set([
+	'server',
+	'date',
+	'content-length',		# ignore content length since we compare the buffer, the content length may be different due to different host name lengths
+	'etag',					# derived from content length
+])
+
+def parseHttpTime(timeStr):
+	return time.mktime(eut.parsedate(timeStr))
+	
+def compareHeaders(headers1, headers2):
+	for headerName in INGORED_HEADERS:
+		headers1.pop(headerName, None)
+		headers2.pop(headerName, None)
+	
+	onlyIn1 = set(headers1.keys()) - set(headers2.keys())
+	if len(onlyIn1) != 0:
+		return 'Error: headers %s found only in headers1' % (','.join(onlyIn1))
+	onlyIn2 = set(headers2.keys()) - set(headers1.keys())
+	if len(onlyIn2) != 0 and onlyIn2 != set(['access-control-allow-origin']):		# allow CORS to be added
+		return 'Error: headers %s found only in headers2' % (','.join(onlyIn2))
+	for curHeader in headers1.keys():
+		if curHeader in IGNORE_HEADER_VALUES:
+			continue
+		value1 = headers1[curHeader]
+		value2 = headers2[curHeader]
+		if value1 == value2:
+			continue
+		if curHeader in set(['expires', 'last-modified']):
+			if abs(parseHttpTime(value1[0]) - parseHttpTime(value2[0])) < 10:
+				continue
+		return 'Error: different value for header %s - %s vs %s' % (curHeader, value1, value2)
+	return None

--- a/test/parse_http_time.py
+++ b/test/parse_http_time.py
@@ -1,0 +1,5 @@
+import email.utils as eut
+import calendar
+import sys
+
+print calendar.timegm(eut.parsedate(sys.argv[1]))

--- a/test/playlist.php
+++ b/test/playlist.php
@@ -113,7 +113,8 @@ if ($playlistType == "live")
 	}
 	
 	// start the playlist from now() - <dvr window size>
-	$currentTime = time() * 1000 - $timeMargin - $dvrWindowSize;
+	$time = isset($params['time']) ? $params['time'] : time();
+	$currentTime = $time * 1000 - $timeMargin - $dvrWindowSize;
 
 	// get the reference time (the time of the first run)
 	$referenceTime = apc_fetch('reference_time');

--- a/test/segmenter_test.py
+++ b/test/segmenter_test.py
@@ -1,0 +1,201 @@
+import itertools
+import sys
+import os
+
+confMatrix = [
+	[
+		('hls', ['vod hls']),
+		('hds', ['vod hds']),
+		('mss', ['vod mss']),
+		('dash-stl', ['vod dash', 'vod_dash_manifest_format segmenttimeline']),
+		('dash-st', ['vod dash', 'vod_dash_manifest_format segmenttemplate']),
+		('dash-sl', ['vod dash', 'vod_dash_manifest_format segmentlist']),
+	],
+	[
+		('zw', ['vod_live_window_duration 0']),
+		('nzw', ['vod_live_window_duration 60000']),
+	],
+	[
+		('sd10', ['vod_segment_duration 9000']),
+		('sd3', ['vod_segment_duration 3000']),
+		('bs', ['vod_bootstrap_segment_durations 1000', 'vod_bootstrap_segment_durations 3000', 'vod_bootstrap_segment_durations 5000']),
+	],
+	[
+		('akf', ['vod_align_segments_to_key_frames on']),
+		('nkf', ['vod_align_segments_to_key_frames off']),
+	],
+	[
+		('sps', ['vod_segment_count_policy last_short']),
+		('spl', ['vod_segment_count_policy last_long']),
+		('spr', ['vod_segment_count_policy last_rounded']),
+	],
+	[
+		('dme', ['vod_manifest_segment_durations_mode estimate']),
+		('dma', ['vod_manifest_segment_durations_mode accurate']),
+	],
+]
+
+fileByProtocol = {
+	'hls': 'master.m3u8',
+	'hds': 'manifest.f4m',
+	'mss': 'manifest',
+	'dash-stl': 'manifest.mpd',
+	'dash-st': 'manifest.mpd',
+	'dash-sl': 'manifest.mpd',
+}
+
+jsonMatrix = [
+	[
+		('type', 'vod'),
+		('type', 'playlist'),
+		('type', 'live'),
+	],
+	[
+		('disc', 'no'),
+		('disc', 'yes'),
+		('disc', 'gap'),
+	],
+	[
+		('kf', 'yes'),		# include key frame durations
+		('kf', 'no'),
+	],
+	[
+		('csmi', 'yes'),	# consistentSequenceMediaInfo
+		('csmi', 'no'),
+	],
+]
+
+liveJsonMatrix = [
+	[
+		('window', '0'),
+		('window', '30'),
+	],
+	[
+		('sbt', 'yes'),		# segmentBaseTime
+		('sbt', 'no'),
+	],
+	[
+		('pet', 'past'),	# presentationEndTime
+		('pet', 'future'),
+	],
+	[
+		('ici', 'yes'),		# initialClipIndex
+		('ici', 'no'),
+	],
+]
+
+hostHeader = 'localhost:8001'
+
+confTemplate = '''
+worker_rlimit_core  500M;
+working_directory   /tmp/;
+
+#user nobody;
+worker_processes  1;
+
+error_log  /var/log/nginx/error_log debug;
+
+pid		/var/run/nginx.pid;
+
+events {
+	worker_connections 4096;
+	multi_accept on;
+	use epoll;
+}
+
+http {
+
+	upstream kalapi {
+		server localhost;
+	}
+	
+	include	   mime.types;
+	default_type  application/octet-stream;
+
+	log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+		'$status $bytes_sent $request_time "$http_referer" "$http_user_agent" '
+		'"$http_host" $pid $request_length "$sent_http_content_range" $connection';
+
+	access_log /var/log/nginx/access_log main;
+
+	server {
+
+		listen	   8001;
+		server_name  vod;
+		
+		# common vod settings
+		vod_mode mapped;
+		vod_upstream_location /kalapi_proxy;
+		vod_max_metadata_size 256m;
+		vod_ignore_edit_list on;
+		vod_max_mapping_response_size 64k;
+		
+		# internal location for vod subrequests
+		location ^~ /kalapi_proxy/ {
+			internal;
+			proxy_pass http://kalapi/segmenter_test_backend.php/loc/;
+			proxy_set_header Host $http_host;
+		}
+		
+		%s
+	}
+}
+'''
+
+def getConf():
+	locations = ''
+	for comb in itertools.product(*confMatrix):
+		locName = '-'.join(map(lambda x: x[0], comb))
+		locDirectives = reduce(lambda x, y: x + y, map(lambda x: x[1], comb))
+		locations += 'location /%s/ {\n%s\n}\n\n' % (locName, 
+			'\n'.join(map(lambda x: '\t%s;' % x, locDirectives)))
+	return confTemplate % locations.replace('\n', '\n\t\t')
+
+def getTestUrls():
+	result = []
+	for confComb in itertools.product(*confMatrix):
+		locName = '-'.join(map(lambda x: x[0], confComb))
+		for baseJsonComb in itertools.product(*jsonMatrix):
+			# decide on the live combinations
+			combDict = dict(confComb + baseJsonComb)
+			if combDict['type'] == 'live':
+				liveCombs = itertools.product(*liveJsonMatrix)
+				
+				if (not combDict.has_key('sps') or 	# segment policy last short is the only option for live
+					combDict.has_key('bs')):		# bootstrap segments not supported for live
+					continue
+			else:
+				liveCombs = [map(lambda x: x[0], liveJsonMatrix)]
+
+				# ignore some 
+				if (combDict.has_key('nzw') or 		# live window relevant only for live
+					combDict['disc'] == 'gap'):		# gap relevant only for live
+					continue
+				if combDict['type'] == 'vod':
+					if combDict['disc'] == 'yes' or combDict['csmi'] == 'no':	# discontinuity and csmi irrelevant for vod
+						continue
+			
+			for liveJsonComb in liveCombs:
+				liveCombDict = dict(liveJsonComb)
+				if combDict['disc'] == 'no' and combDict['type'] == 'live' and liveCombDict['sbt'] == 'no':
+					continue	# segment base time mandatory in continuous live
+				if combDict['type'] in set(['live', 'playlist']) and liveCombDict['sbt'] == 'yes' and combDict['disc'] == 'yes':
+					continue	# passing segment base time with multi clip in discontinuous mode will result in error of gap too small
+					
+				# build the url
+				jsonComb = list(baseJsonComb) + list(liveJsonComb)
+				url = '/' + locName + ''.join(map(lambda (x): '/%s/%s' % x, jsonComb)) + \
+					'/time/@time@' + \
+					'/' + fileByProtocol[confComb[0][0]]
+				result.append(url)
+	return result
+
+if len(sys.argv) < 2:
+	print 'Usage:\n\t%s urls/conf' % os.path.basename(__file__)
+	sys.exit(1)
+
+if sys.argv[1] == 'conf':
+	print getConf()
+else:
+	for url in getTestUrls():
+		print hostHeader, url

--- a/test/segmenter_test_backend.php
+++ b/test/segmenter_test_backend.php
@@ -1,0 +1,182 @@
+<?php
+
+// pseudo random generator (must generate consistent results)
+class Random 
+{
+	private $RSeed = 0;
+
+	public function __construct($s = 0) 
+	{
+		$this->RSeed = abs(intval($s)) % 9999999 + 1;
+		$this->num();
+	}
+
+	public function num($min, $max)
+	{
+		if ($this->RSeed == 0) $this->seed(mt_rand());
+		$this->RSeed = ($this->RSeed * 125) % 2796203;
+		return $this->RSeed % ($max - $min + 1) + $min;
+	}
+}
+
+function getRequestParams()
+{
+        $scriptParts = explode('/', $_SERVER['SCRIPT_NAME']);
+        $pathParts = array();
+        if (isset($_SERVER['PHP_SELF']))
+                $pathParts = explode('/', $_SERVER['PHP_SELF']);
+        $pathParts = array_diff($pathParts, $scriptParts);
+
+        $params = array();
+        reset($pathParts);
+        while(current($pathParts))
+        {
+                $key = each($pathParts);
+                $value = each($pathParts);
+                if (!array_key_exists($key['value'], $params))
+                {
+                        $params[$key['value']] = $value['value'];
+                }
+        }
+        return $params;
+}
+
+function getSourceClip($filePath)
+{
+	return array(
+		"type" => "source",
+		"path" => $filePath
+	);
+}
+
+// input params
+$filePaths = array(
+	"/web/content/r71v1/entry/data/241/803/0_p7y00o7h_0_93j6yqit_1.mp4",
+	"/web/content/r70v1/entry/data/138/192/1_46gm1o7f_1_22any1sp_1.mp4",
+	"/web/content/r70v1/entry/data/138/192/1_5bik2rp6_1_kg6dq8kb_1.mp4",
+	);
+
+$durations = array(
+	34469,
+	46738,
+	24936,
+);
+
+$gapSize = 23456;
+
+$sumDurations = array_sum($durations);
+
+// validate input
+$paramValues = array(
+	'type' => array('vod', 'playlist', 'live'),
+	'disc' => array('no', 'yes', 'gap'),
+	'kf' => array('yes', 'no'),			// include key frame durations
+	'csmi' => array('yes', 'no'),		// consistentSequenceMediaInfo
+	'sbt' => array('yes', 'no'),		// segmentBaseTime
+	'ici' => array('yes', 'no'),		// initialClipIndex
+	'pet' => array('past', 'future'),	// presentationEndTime
+);
+
+$params = getRequestParams();
+foreach ($paramValues as $paramName => $values)
+{
+	if (!in_array($params[$paramName], $values)) 
+	{
+		die("invalid value for '{$paramName}', must be one of [".implode(',', $values)."]\n");
+	}
+}
+
+if (!is_numeric($params['window']))
+{
+	die("invalid value for 'window', must be numeric\n");
+}
+
+// build the sequence
+$sequence = array();
+if ($params['kf'] == 'yes')
+{
+	$r = new Random();
+	$curPos = -500;
+	$sequence["firstKeyFrameOffset"] = $curPos;
+	$limit = $sumDurations + $gapSize * count($durations);
+	$kfDurations = array();
+	while ($curPos < $limit)
+	{
+		$curDuration = $r->num(1000, 5000);
+		$kfDurations[] = $curDuration;
+		$curPos += $curDuration;
+	}
+	$sequence["keyFrameDurations"] = $kfDurations;
+}
+
+// parse the input
+$discontinuity = $params['disc'] != 'no';
+$playlistType = $params['type'];
+$time = isset($params['time']) ? $params['time'] : time();
+
+$mediaSet = array();
+
+switch ($playlistType)
+{
+case 'vod':
+	$sequence["clips"] = array(getSourceClip($filePaths[0]));
+	$mediaSet = array_merge($mediaSet, array(
+		"sequences" => array($sequence)
+	));
+	die(json_encode($mediaSet));
+	
+case 'playlist':
+	$playlistType = 'vod';		// playlist needs to be returned as vod
+	break;
+	
+case 'live':
+	$firstClipTime = $time * 1000 - floor($sumDurations / 2);
+	$roundTo = floor($sumDurations / 4);
+	$firstClipTime = floor($firstClipTime / $roundTo) * $roundTo;
+	if ($params['disc'] == 'gap')
+	{
+		$curTime = $firstClipTime;
+		$clipTimes = array();
+		foreach ($durations as $duration)
+		{
+			$clipTimes[] = $curTime;
+			$curTime += $duration + 23456;
+		}
+		$mediaSet["clipTimes"] = $clipTimes;
+	}
+	else
+	{
+		$mediaSet["firstClipTime"] = $firstClipTime;
+	}
+	
+	if ($discontinuity)
+	{	
+		if ($params['ici'] == 'yes')
+		{
+			$mediaSet["initialClipIndex"] = 123;
+		}
+		$mediaSet["initialSegmentIndex"] = 234;
+	}
+	
+	if ($params['sbt'] == 'yes')
+	{
+		$mediaSet["segmentBaseTime"] = 733038085;
+	}
+	
+	$mediaSet["liveWindowDuration"] = intval($params['window']) * 1000;
+	$mediaSet["presentationEndTime"] = $time * 1000 + ($params['pet'] == 'past' ? -100000 : 100000);
+	break;
+}
+
+$sequence["clips"] = array_map('getSourceClip', $filePaths);
+
+// generate the result object
+$mediaSet = array_merge($mediaSet, array(
+	"discontinuity" => $discontinuity,
+	"playlistType" => $playlistType,
+	"durations" => $durations,
+	"sequences" => array($sequence),
+	"consistentSequenceMediaInfo" => $params['csmi'] == 'yes',
+));
+
+echo json_encode($mediaSet);

--- a/test/stream_compare.py
+++ b/test/stream_compare.py
@@ -1,0 +1,72 @@
+import manifest_utils
+import compare_utils
+import stress_base
+import http_utils
+import random
+import time
+import re
+
+from stream_compare_params import *
+
+class TestThread(stress_base.TestThreadBase):
+
+	def getURL(self, hostHeader, url):
+		headers = {}
+		headers.update(EXTRA_HEADERS)
+		headers['Host'] = hostHeader
+		code, headers, body = http_utils.getUrl(url, headers)
+		if code == 0:
+			self.writeOutput(body)
+		return code, headers, body
+		
+	def compareUrls(self, hostHeader, url1, url2):
+		code1, headers1, body1 = self.getURL(hostHeader, url1)
+		code2, headers2, body2 = self.getURL(hostHeader, url2)
+		if code1 != code2:
+			self.writeOutput('Error: got different status codes %s vs %s, url1=%s, url2=%s' % (code1, code2, url1, url2))
+			return False
+		
+		headerCompare = compare_utils.compareHeaders(headers1, headers2)
+		if headerCompare != None:
+			self.writeOutput(headerCompare)
+			return False
+		
+		if str(code1) != '200':
+			self.writeOutput('Notice: got status code %s, url1=%s, url2=%s' % (code1, url1, url2))
+					
+		if body1 != body2:
+			self.writeOutput('Error: comparison failed, url1=%s, url2=%s' % (url1, url2))
+			self.writeOutput(body1)
+			self.writeOutput(body2)
+			return False
+			
+		return code1, headers1, body1
+		
+	def runTest(self, uri):
+		hostHeader, uri = uri.split(' ')
+	
+		uri = uri.replace('@time@', str(int(time.time())))
+		urlBase1 = random.choice(URL1_BASE)
+		urlBase2 = random.choice(URL2_BASE)
+		url1 = urlBase1 + uri
+		url2 = urlBase2 + uri
+		
+		self.writeOutput('Info: testing %s %s' % (url1, url2))
+		compareResult = self.compareUrls(hostHeader, url1, url2)
+		if compareResult == False:
+			return False
+		code, headers, body = compareResult
+		if str(code) != '200':
+			return True
+		
+		mimeType = headers['content-type'][0]
+		urls = manifest_utils.getManifestUrls(url1.rsplit('/', 1)[0], body, mimeType, {})
+
+		result = True
+		for url in urls:
+			if not self.compareUrls(hostHeader, url, url.replace(urlBase1, urlBase2)):
+				result = False
+		return result
+
+if __name__ == '__main__':
+	stress_base.main(TestThread, STOP_FILE)

--- a/test/stream_compare_params.py.template
+++ b/test/stream_compare_params.py.template
@@ -1,0 +1,6 @@
+
+STOP_FILE = '/tmp/stream_compare_stop'
+URL1_BASE = ['http://localhost:8001']
+URL2_BASE = ['http://localhost:8001']
+
+EXTRA_HEADERS = {}

--- a/vod/common.h
+++ b/vod/common.h
@@ -146,7 +146,12 @@ void vod_log_error(vod_uint_t level, vod_log_t *log, int err,
 #define vod_hash_find(hash, key, name, len) ngx_hash_find(hash, key, name, len)
 
 // time functions
-#define vod_time() ngx_time()
+#if (NGX_DEBUG)
+#define vod_time(request_context) (request_context->time > 0 ? request_context->time : ngx_time())
+#else
+#define vod_time(request_context) ngx_time()
+#endif
+
 #define vod_gmtime(t, tp) ngx_gmtime(t, tp)
 #define vod_tm_sec   ngx_tm_sec
 #define vod_tm_min   ngx_tm_min
@@ -287,6 +292,9 @@ typedef struct {
 	vod_log_t *log;
 	buffer_pool_t* output_buffer_pool;
 	bool_t simulation_only;
+#if (NGX_DEBUG)
+	time_t time;
+#endif
 } request_context_t;
 
 enum {

--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -428,7 +428,8 @@ dash_packager_get_track_spec(
 {
 	u_char* p = result->data;
 
-	if (media_set->use_discontinuity)
+	if (media_set->use_discontinuity && 
+		media_set->initial_clip_index != INVALID_CLIP_INDEX)
 	{
 		p = vod_sprintf(p, "c%uD-", media_set->initial_clip_index + clip_index + 1);
 	}

--- a/vod/media_set.h
+++ b/vod/media_set.h
@@ -81,6 +81,7 @@ typedef struct {
 	uint64_t segment_base_time;			// the time of segment 0
 	uint64_t total_duration;			// = sum(durations)
 	uint64_t first_time;				// = times[0]
+	uint32_t first_segment_alignment_offset;	// difference between unaligned first segment time and first_time
 } media_clip_timing_t;
 
 typedef struct {

--- a/vod/media_set_parser.c
+++ b/vod/media_set_parser.c
@@ -1105,10 +1105,6 @@ media_set_parse_live_params(
 		{
 			media_set->timing.segment_base_time = params[MEDIA_SET_PARAM_SEGMENT_BASE_TIME]->v.num.nom;
 		}
-		else
-		{
-			media_set->timing.segment_base_time = SEGMENT_BASE_TIME_RELATIVE;
-		}
 	}
 	else
 	{
@@ -1240,7 +1236,8 @@ media_set_parse_json(
 
 	result->timing.times = NULL;
 	result->timing.first_time = 0;
-	result->timing.segment_base_time = 0;
+	result->timing.segment_base_time = SEGMENT_BASE_TIME_RELATIVE;
+	result->timing.first_segment_alignment_offset = 0;
 	result->initial_segment_index = 0;
 	result->initial_clip_index = 0;
 
@@ -1306,7 +1303,7 @@ media_set_parse_json(
 	{
 		result->type = MEDIA_SET_LIVE;
 		result->presentation_end = params[MEDIA_SET_PARAM_PRESENTATION_END_TIME] != NULL &&
-			params[MEDIA_SET_PARAM_PRESENTATION_END_TIME]->v.num.nom <= (int64_t)vod_time() * 1000;
+			params[MEDIA_SET_PARAM_PRESENTATION_END_TIME]->v.num.nom <= (int64_t)vod_time(request_context) * 1000;
 	}
 	else
 	{
@@ -1378,11 +1375,6 @@ media_set_parse_json(
 		if (rc != VOD_OK)
 		{
 			return rc;
-		}
-
-		if (result->use_discontinuity)
-		{
-			result->timing.segment_base_time = SEGMENT_BASE_TIME_RELATIVE;
 		}
 	}
 

--- a/vod/mss/mss_packager.c
+++ b/vod/mss/mss_packager.c
@@ -747,7 +747,6 @@ mss_packager_build_fragment_header(
 		sequence,
 		moof_atom_size + ATOM_HEADER_SIZE);
 
-
 	if (media_set->type == MEDIA_SET_LIVE)
 	{
 		// using only estimate timing info in live, since we don't have the accurate timing


### PR DESCRIPTION
- when reaching the align to key frame limit, the key frame duration was counted twice
- when end time exceeds the clip end need to update it (not only the end offset)
- when key frame alignment is enabled and segment base time is relative, need to calculate segments from the original clip start, not the aligned start
- initial segment index needs to be incremented by start_clip_offset / conf->segment_duration not div_ceil
- segmenter_get_segment_durations_estimate: need to copy additional fields when there is no discontinuity
- snap end to segment boundary before processing start, so that the configured live window duration will be honored (got a smaller value due to rounding effects of both start and end)
- get live window: in continuous mode there isn't necessarily a segment boundary in clip boundary, treat all clips as a single clip

also:
- decode json when the mapping matches the prefix & suffix
- allow overriding the server time in debug builds
- change segment_base_time to be relative by default
- output discontinuity indicator in hds
- add test matrix for all segmenter options