### PR TITLE
use a clip index only in dash init segments

### DIFF
--- a/ngx_http_vod_dash.c
+++ b/ngx_http_vod_dash.c
@@ -501,7 +501,7 @@ ngx_http_vod_dash_parse_uri_file_name(
 		start_pos += conf->dash.mpd_config.init_file_name_prefix.len;
 		end_pos -= (sizeof(init_segment_file_ext) - 1);
 		*request = &dash_mp4_init_request;
-		flags = 0;
+		flags = PARSE_FILE_NAME_ALLOW_CLIP_INDEX;
 	}
 	// webm fragment
 	else if (ngx_http_vod_match_prefix_postfix(start_pos, end_pos, &conf->dash.mpd_config.fragment_file_name_prefix, webm_file_ext))
@@ -517,7 +517,7 @@ ngx_http_vod_dash_parse_uri_file_name(
 		start_pos += conf->dash.mpd_config.init_file_name_prefix.len;
 		end_pos -= (sizeof(webm_file_ext) - 1);
 		*request = &dash_webm_init_request;
-		flags = 0;
+		flags = PARSE_FILE_NAME_ALLOW_CLIP_INDEX;
 	}
 	// manifest
 	else if (ngx_http_vod_match_prefix_postfix(start_pos, end_pos, &conf->dash.manifest_file_name_prefix, manifest_file_ext))

--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -260,7 +260,7 @@ ngx_http_vod_parse_uri_file_name(
 	skip_dash(start_pos, end_pos);
 
 	// clip index
-	if (*start_pos == 'c')
+	if (*start_pos == 'c' && (flags & PARSE_FILE_NAME_ALLOW_CLIP_INDEX) != 0)
 	{
 		start_pos++;		// skip the c
 

--- a/ngx_http_vod_request_parse.h
+++ b/ngx_http_vod_request_parse.h
@@ -13,6 +13,7 @@
 
 #define PARSE_FILE_NAME_EXPECT_SEGMENT_INDEX	(0x1)
 #define PARSE_FILE_NAME_MULTI_STREAMS_PER_TYPE	(0x2)
+#define PARSE_FILE_NAME_ALLOW_CLIP_INDEX		(0x4)
 
 // macros
 #define ngx_http_vod_starts_with(start_pos, end_pos, prefix)	\


### PR DESCRIPTION
the fragments no longer need the clip index, since the fragment index is no longer relative to the clip start