### PR TITLE
support getting a language param in index.m3u8

### DIFF
--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -402,7 +402,6 @@ ngx_http_vod_set_request_params_var(ngx_http_request_t *r, ngx_http_variable_val
 		request_params->sequences_mask,
 		request_params->sequence_tracks_mask,
 		request_params->tracks_mask,
-		&empty_string,
 		&value);
 	if (rc != VOD_OK)
 	{

--- a/vod/hds/hds_manifest.c
+++ b/vod/hds/hds_manifest.c
@@ -602,7 +602,7 @@ hds_packager_build_manifest(
 
 				p = vod_sprintf(p, HDS_BOOTSTRAP_LIVE_PREFIX, index);
 				p = vod_copy(p, conf->bootstrap_file_name_prefix.data, conf->bootstrap_file_name_prefix.len);
-				p = manifest_utils_append_tracks_spec(p, tracks, media_set->has_multi_sequences);
+				p = manifest_utils_append_tracks_spec(p, tracks, MEDIA_TYPE_COUNT, media_set->has_multi_sequences);
 				p = vod_copy(p, HDS_BOOTSTRAP_LIVE_SUFFIX, sizeof(HDS_BOOTSTRAP_LIVE_SUFFIX) - 1);
 				break;
 			}
@@ -702,7 +702,7 @@ hds_packager_build_manifest(
 
 			// url
 			p = vod_copy(p, conf->fragment_file_name_prefix.data, conf->fragment_file_name_prefix.len);
-			p = manifest_utils_append_tracks_spec(p, tracks, media_set->has_multi_sequences);
+			p = manifest_utils_append_tracks_spec(p, tracks, MEDIA_TYPE_COUNT, media_set->has_multi_sequences);
 			*p++ = '-';
 
 			if (drm_enabled)

--- a/vod/manifest_utils.h
+++ b/vod/manifest_utils.h
@@ -46,10 +46,13 @@ vod_status_t manifest_utils_build_request_params_string(
 	uint32_t sequences_mask,
 	uint32_t* sequence_tracks_mask,
 	uint32_t* tracks_mask,
-	vod_str_t* suffix,
 	vod_str_t* result);
 
-u_char* manifest_utils_append_tracks_spec(u_char* p, media_track_t** tracks, bool_t write_sequence_index);
+u_char* manifest_utils_append_tracks_spec(
+	u_char* p,
+	media_track_t** tracks,
+	uint32_t track_count,
+	bool_t write_sequence_index);
 
 vod_status_t manifest_utils_get_adaptation_sets(
 	request_context_t* request_context,


### PR DESCRIPTION
use the actual track ids for the segment urls instead of passing the track ids of the request