### PR TITLE
disable the use of open file cache for mapping

### DIFF
--- a/ngx_file_reader.c
+++ b/ngx_file_reader.c
@@ -102,7 +102,8 @@ ngx_file_reader_init(
 	void* callback_context,
 	ngx_http_request_t *r,
 	ngx_http_core_loc_conf_t *clcf,
-	ngx_str_t* path)
+	ngx_str_t* path,
+	uint32_t flags)
 {
 	ngx_open_file_info_t of;
 	ngx_int_t rc;
@@ -125,7 +126,11 @@ ngx_file_reader_init(
 		return rc;
 	}
 
-	rc = ngx_open_cached_file(clcf->open_file_cache, path, &of, r->pool);
+	rc = ngx_open_cached_file(
+		(flags & OPEN_FILE_NO_CACHE) != 0 ? NULL : clcf->open_file_cache, 
+		path, 
+		&of, 
+		r->pool);
 
 	return ngx_file_reader_update_state_file_info(state, &of, rc);
 }
@@ -168,7 +173,8 @@ ngx_file_reader_init_async(
 	void* callback_context,
 	ngx_http_request_t *r,
 	ngx_http_core_loc_conf_t *clcf,
-	ngx_str_t* path)
+	ngx_str_t* path,
+	uint32_t flags)
 {
 	ngx_file_reader_async_open_context_t* open_context;
 	ngx_int_t rc;
@@ -213,7 +219,7 @@ ngx_file_reader_init_async(
 	}
 
 	rc = ngx_async_open_cached_file(
-		clcf->open_file_cache,
+		(flags & OPEN_FILE_NO_CACHE) != 0 ? NULL : clcf->open_file_cache, 
 		path,
 		&open_context->of,
 		r->pool,

--- a/ngx_file_reader.h
+++ b/ngx_file_reader.h
@@ -11,6 +11,9 @@
 #include "ngx_async_open_file_cache.h"
 #endif
 
+// constants
+#define OPEN_FILE_NO_CACHE (0x1)
+
 // typedefs
 typedef void (*ngx_async_read_callback_t)(void* context, ngx_int_t rc, ngx_buf_t* buf, ssize_t bytes_read);
 
@@ -36,7 +39,8 @@ ngx_int_t ngx_file_reader_init(
 	void* callback_context,
 	ngx_http_request_t *r,
 	ngx_http_core_loc_conf_t  *clcf,
-	ngx_str_t* path);
+	ngx_str_t* path,
+	uint32_t flags);
 
 #if (NGX_THREADS)
 ngx_int_t ngx_file_reader_init_async(
@@ -48,7 +52,8 @@ ngx_int_t ngx_file_reader_init_async(
 	void* callback_context,
 	ngx_http_request_t *r,
 	ngx_http_core_loc_conf_t  *clcf,
-	ngx_str_t* path);
+	ngx_str_t* path,
+	uint32_t flags);
 #endif
 
 ngx_int_t ngx_file_reader_dump_file_part(ngx_file_reader_state_t* state, off_t start, off_t end);


### PR DESCRIPTION
required for live, since the json file is constantly updated.
also, this cache does not provide any value for jsons, since the files are
small enough to keep all their content in vod_mapping_cache