### PR TITLE
Separate live expires

### DIFF
--- a/README.md
+++ b/README.md
@@ -1040,14 +1040,21 @@ This directive is similar to nginx's built-in `expires` directive, except that i
 (epoch, max, off, day time are not supported)
 Main motivation for using this directive instead of the built-in `expires` is to have different expiration for VOD and dynamic live content.
 If this directive is not specified, nginx-vod-module will not set the "Expires" / "Cache-Control" headers.
+This setting affects - all types of requests in VOD playlists, segment requests in live playlists.
 
 #### vod_expires_live
 * **syntax**: `vod_expires_live time`
 * **default**: `none`
 * **context**: `http`, `server`, `location`
 
-Same as `vod_expires` (above) for dynamic live content.
-In DASH, for example, the expiration of the video fragments is determined by `vod_expires`, while `vod_expires_live` determines the expiration of the MPD.
+Same as `vod_expires` (above) for live requests that are not time dependent and not segments (e.g. HLS - master.m3u8, HDS - manifest.f4m).
+
+#### vod_expires_live_time_dependent
+* **syntax**: `vod_expires_live_time_dependent time`
+* **default**: `none`
+* **context**: `http`, `server`, `location`
+
+Same as `vod_expires` (above) for live requests that are time dependent (HLS - index.m3u8, HDS - bootstrap.abst, MSS - manifest, DASH - manifest.mpd).
 
 #### vod_last_modified
 * **syntax**: `vod_last_modified time`
@@ -1058,7 +1065,7 @@ Sets the value of the Last-Modified header returned on the response, by default 
 The reason for having this parameter here is in order to support If-Modified-Since / If-Unmodified-Since.
 Since nginx's builtin ngx_http_not_modified_filter_module runs before any other header filter module, it will not see any headers set by add_headers / more_set_headers.
 This makes nginx always reply as if the content changed (412 for If-Unmodified-Since / 200 for If-Modified-Since)
-For changing live content (e.g. live DASH MPD), Last-Modified is set to the current server time.
+For live requests that are not segments (e.g. live DASH MPD), Last-Modified is set to the current server time.
 
 #### vod_last_modified_types
 * **syntax**: `vod_last_modified_types mime-type1 mime-type2 ...`

--- a/README.md
+++ b/README.md
@@ -1040,7 +1040,7 @@ This directive is similar to nginx's built-in `expires` directive, except that i
 (epoch, max, off, day time are not supported)
 Main motivation for using this directive instead of the built-in `expires` is to have different expiration for VOD and dynamic live content.
 If this directive is not specified, nginx-vod-module will not set the "Expires" / "Cache-Control" headers.
-This setting affects - all types of requests in VOD playlists, segment requests in live playlists.
+This setting affects all types of requests in VOD playlists and segment requests in live playlists.
 
 #### vod_expires_live
 * **syntax**: `vod_expires_live time`

--- a/ngx_http_vod_conf.h
+++ b/ngx_http_vod_conf.h
@@ -13,6 +13,14 @@
 
 // enum
 enum {
+	EXPIRES_TYPE_VOD,
+	EXPIRES_TYPE_LIVE,
+	EXPIRES_TYPE_LIVE_TIME_DEPENDENT,
+
+	EXPIRES_TYPE_COUNT
+};
+
+enum {
 	CACHE_TYPE_VOD,
 	CACHE_TYPE_LIVE,
 
@@ -56,7 +64,7 @@ struct ngx_http_vod_loc_conf_s {
 	ngx_str_t fallback_upstream_location;
 	ngx_table_elt_t proxy_header;
 
-	time_t expires[CACHE_TYPE_COUNT];
+	time_t expires[EXPIRES_TYPE_COUNT];
 	time_t last_modified_time;
 	ngx_hash_t  last_modified_types;
 	ngx_array_t *last_modified_types_keys;

--- a/ngx_http_vod_submodule.h
+++ b/ngx_http_vod_submodule.h
@@ -21,12 +21,10 @@
 	((submodule_context)->r->header_only || (submodule_context)->r->method == NGX_HTTP_HEAD)
 
 // request classes
-enum {
-	REQUEST_CLASS_MANIFEST,
-	REQUEST_CLASS_SEGMENT,
-	REQUEST_CLASS_THUMB,
-	REQUEST_CLASS_OTHER,		// dash init segment, hls iframes manifest, hls master manifest, hls encryption key
-};
+#define REQUEST_CLASS_MANIFEST	(0x01)
+#define REQUEST_CLASS_SEGMENT	(0x02)
+#define REQUEST_CLASS_THUMB		(0x04)
+#define REQUEST_CLASS_OTHER		(0x08)		// dash init segment, hls iframes manifest, hls master manifest, hls encryption key
 
 struct ngx_http_vod_loc_conf_s;
 


### PR DESCRIPTION
vod_expires_live_time_dependent - live requests that depend on the live window
vod_expires_live - all other live requests except segments (segments use vod_expires)