### PR TITLE
block requests to future segments in live

### DIFF
--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -1234,6 +1234,7 @@ ngx_http_vod_parse_metadata(
 			get_ranges_params.conf = segmenter;
 			get_ranges_params.last_segment_end = last_segment_end;
 			get_ranges_params.key_frame_durations = NULL;
+			get_ranges_params.allow_last_segment = TRUE;
 
 			ngx_memzero(&get_ranges_params.timing, sizeof(get_ranges_params.timing));
 			get_ranges_params.timing.durations = &duration_millis;

--- a/test/segmenter_test_backend.php
+++ b/test/segmenter_test_backend.php
@@ -174,7 +174,7 @@ case 'live':
 	}
 	
 	$mediaSet["liveWindowDuration"] = intval($params['window']) * 1000;
-	$mediaSet["presentationEndTime"] = $time * 1000 + ($params['pet'] == 'past' ? -100000 : 100000);
+	$mediaSet["presentationEndTime"] = $time * 1000 + ($params['pet'] == 'past' ? -1000000 : 1000000);
 	break;
 }
 

--- a/vod/media_set_parser.c
+++ b/vod/media_set_parser.c
@@ -1320,6 +1320,13 @@ media_set_init_look_ahead_segments(
 
 		if (clip_ranges.clip_count <= 0)
 		{
+			if (!media_set->presentation_end)
+			{
+				vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+					"media_set_init_look_ahead_segments: failed to get look ahead segment");
+				return VOD_BAD_REQUEST;
+			}
+
 			break;
 		}
 
@@ -1840,6 +1847,7 @@ media_set_parse_json(
 		get_ranges_params.timing = result->timing;
 		get_ranges_params.first_key_frame_offset = result->sequences[0].first_key_frame_offset;
 		get_ranges_params.key_frame_durations = result->sequences[0].key_frame_durations;
+		get_ranges_params.allow_last_segment = result->presentation_end;
 
 		if (request_params->segment_index != INVALID_SEGMENT_INDEX)
 		{

--- a/vod/mss/mss_packager.c
+++ b/vod/mss/mss_packager.c
@@ -159,6 +159,11 @@ mss_write_manifest_chunks_live(u_char* p, segment_durations_t* segment_durations
 	{
 		repeat_count = cur_item->repeat_count;
 
+		if (cur_item->duration == 0)
+		{
+			continue;
+		}
+
 		// output the timestamp in the first chunk
 		if (first_time)
 		{

--- a/vod/segmenter.h
+++ b/vod/segmenter.h
@@ -39,6 +39,7 @@ typedef struct {
 	uint32_t segment_index;
 	int64_t first_key_frame_offset;
 	vod_array_part_t* key_frame_durations;
+	bool_t allow_last_segment;
 
 	// no discontinuity
 	uint64_t last_segment_end;


### PR DESCRIPTION
if presentation end is false, any requests past the end of the playlist
must return an error instead of returning a partial segment