### PR TITLE
update segmenter test to support live dash

### DIFF
--- a/test/segmenter_test.py
+++ b/test/segmenter_test.py
@@ -71,8 +71,8 @@ liveJsonMatrix = [
 		('window', '30'),
 	],
 	[
-		('sbt', 'yes'),		# segmentBaseTime
-		('sbt', 'no'),
+		('sbt', 'no'),		# segmentBaseTime
+		('sbt', 'yes'),
 	],
 	[
 		('pet', 'past'),	# presentationEndTime
@@ -129,6 +129,11 @@ http {
 		vod_max_metadata_size 256m;
 		vod_ignore_edit_list on;
 		vod_max_mapping_response_size 64k;
+		vod_hls_output_id3_timestamps on;
+		add_header 'Access-Control-Allow-Headers' 'Origin,Range,Accept-Encoding,Referer,Cache-Control';
+		add_header 'Access-Control-Expose-Headers' 'Server,Content-Length,Content-Range,Date';
+		add_header 'Access-Control-Allow-Methods' 'GET, HEAD, OPTIONS';
+		add_header 'Access-Control-Allow-Origin' '*';
 		
 		# internal location for vod subrequests
 		location ^~ /kalapi_proxy/ {

--- a/test/stream_compare.py
+++ b/test/stream_compare.py
@@ -1,3 +1,4 @@
+from urlparse import urlparse
 import manifest_utils
 import compare_utils
 import stress_base
@@ -61,6 +62,7 @@ class TestThread(stress_base.TestThreadBase):
 		
 		mimeType = headers['content-type'][0]
 		urls = manifest_utils.getManifestUrls(url1.rsplit('/', 1)[0], body, mimeType, {})
+		urls = map(lambda x: urlBase1 + urlparse(x).path, urls)		# the urls may contain the host header
 
 		result = True
 		for url in urls:

--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -819,6 +819,8 @@ dash_packager_write_mpd_period(
 				media_set->timing.times[context->clip_index + 1])
 			{
 				// there is a gap after this clip, output start time and duration
+				clip_duration += media_set->timing.times[context->clip_index] - context->clip_start_time;
+
 				p = vod_sprintf(p,
 					VOD_DASH_MANIFEST_PERIOD_HEADER_START_DURATION,
 					media_set->initial_clip_index + context->clip_index,

--- a/vod/segmenter.c
+++ b/vod/segmenter.c
@@ -996,7 +996,7 @@ segmenter_get_live_window_start_end(
 
 		if (end_time <= timing->times[end_clip_index])
 		{
-			// end slipped to the previous segment
+			// end slipped to the previous clip
 			if (end_clip_index <= 0)
 			{
 				vod_log_error(VOD_LOG_ERR, request_context->log, 0,
@@ -1094,7 +1094,7 @@ segmenter_get_live_window_start_end(
 
 	if (start_time >= clip_end_time)
 	{
-		// start slipped to the next segment
+		// start slipped to the next clip
 		start_clip_index++;
 		if (start_clip_index > end_clip_index)
 		{
@@ -1489,6 +1489,7 @@ segmenter_get_segment_durations_estimate_internal(
 		// there may be zero duration segments at the end due to key frame alignment, if so, strip them off
 		if (context.cur_item->duration == 0)
 		{
+			context.result->segment_count -= context.cur_item->repeat_count;
 			context.cur_item--;
 		}
 

--- a/vod/segmenter.c
+++ b/vod/segmenter.c
@@ -1143,6 +1143,8 @@ segmenter_get_live_window(
 	uint32_t* durations_end;
 	uint32_t* durations_cur;
 	uint32_t total_duration;
+	uint32_t clip_initial_segment_index;
+	uint32_t initial_segment_index;
 
 	if (media_set->use_discontinuity)
 	{
@@ -1170,6 +1172,16 @@ segmenter_get_live_window(
 
 			media_set->initial_segment_clip_relative_index = window.start_clip_offset / conf->segment_duration;
 			media_set->initial_segment_index += media_set->initial_segment_clip_relative_index;
+		}
+		else
+		{
+			clip_initial_segment_index = segmenter_get_segment_index_no_discontinuity(
+				conf,
+				timing->times[window.start_clip_index] - timing->segment_base_time);
+			initial_segment_index = segmenter_get_segment_index_no_discontinuity(
+				conf,
+				window.start_time - timing->segment_base_time);
+			media_set->initial_segment_clip_relative_index = initial_segment_index - clip_initial_segment_index;
 		}
 	}
 	else


### PR DESCRIPTION
also:
- when there is gap in live dash, output the period duration as well as start time, otherwise the gap is not reflected in the manifest
- when removing trailing zero segments from a clip, need to update the segment count (not updating it can cause a dash manifest to contain more segments than it should)