### PR TITLE
hbbtv supportive features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1016,6 +1016,8 @@ Configures the shared memory object name of the performance counters
 
 Sets the base URL (scheme + domain) that should be returned in manifest responses.
 The parameter value can contain variables, if the parameter evaluates to an empty string, relative URLs will be used.
+If the parameter evaluates to a string ending with /, it is assumed to be a full URL - the module only appends the
+file name to it, instead of a full URI.
 If not set, the base URL is determined as follows:
 1. If the request did not contain a host header (HTTP/1.0) relative URLs will be returned
 2. Otherwise, the base URL will be `$scheme://$http_host`

--- a/ngx_http_vod_utils.c
+++ b/ngx_http_vod_utils.c
@@ -28,6 +28,8 @@ static ngx_str_t error_codes[VOD_ERROR_LAST - VOD_ERROR_FIRST] = {
 
 static ngx_uint_t ngx_http_vod_status_index;
 
+static ngx_str_t empty_string = ngx_null_string;
+
 void ngx_http_vod_set_status_index(ngx_uint_t index)
 {
 	ngx_http_vod_status_index = index;
@@ -204,6 +206,11 @@ ngx_http_vod_get_base_url(
 		{
 			// conf base url evaluated to empty string, use relative URLs
 			return NGX_OK;
+		}
+
+		if (base_url.data[base_url.len - 1] == '/')
+		{
+			file_uri = &empty_string;
 		}
 
 		result_size = base_url.len;


### PR DESCRIPTION
- support disabling a cache specified in a higher level
- support using $vod_suburi during mapping
- when $vod_base_url evaluates to a string that ends with /, assume it's a full url - do not add the uri to it