### PR TITLE
hbbtv supportive features - part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,16 @@ See the list of nginx variables added by this module below.
 When enabled, the module encrypts the media segments according to the response it gets from the drm upstream.
 Currently supported only for dash and mss (play ready).
 
+#### vod_drm_single_key
+* **syntax**: `vod_drm_single_key on/off`
+* **default**: `off`
+* **context**: `http`, `server`, `location`
+
+When enabled, the module requests the drm info only for the first sequence and applies it to all sequences.
+When disabled, the drm info is requested for each sequence separately.
+In addition, in DASH, enabling this setting makes the module place the ContentProtection tag under AdaptationSet,
+otherwise, it is placed under Representation.
+
 #### vod_drm_clear_lead_segment_count
 * **syntax**: `vod_drm_clear_lead_segment_count count`
 * **default**: `1`
@@ -1287,6 +1297,14 @@ Sets the MPD format, available options are:
 * `segmentlist` - uses SegmentList and SegmentURL tags, in this format the URL of each fragment is explicitly set in the MPD
 * `segmenttemplate` - uses SegmentTemplate, reporting a single duration for all fragments
 * `segmenttimeline` - uses SegmentTemplate and SegmentTimeline to explicitly set the duration of the fragments
+
+#### vod_dash_init_mp4_pssh
+* **syntax**: `vod_dash_init_mp4_pssh on/off`
+* **default**: `on`
+* **context**: `http`, `server`, `location`
+
+When enabled, the DRM pssh boxes are returned in the DASH init segment and in the manifest.
+When disabled, the pssh boxes are returned only in the manifest.
 
 ### Configuration directives - HDS
 

--- a/ngx_http_vod_conf.c
+++ b/ngx_http_vod_conf.c
@@ -99,6 +99,7 @@ ngx_http_vod_create_loc_conf(ngx_conf_t *cf)
 	conf->last_modified_time = NGX_CONF_UNSET;
 
 	conf->drm_enabled = NGX_CONF_UNSET;
+	conf->drm_single_key = NGX_CONF_UNSET;
 	conf->drm_clear_lead_segment_count = NGX_CONF_UNSET_UINT;
 	conf->drm_max_info_length = NGX_CONF_UNSET_SIZE;
 	conf->drm_info_cache = NGX_CONF_UNSET_PTR;
@@ -247,6 +248,7 @@ ngx_http_vod_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 	}
 
 	ngx_conf_merge_value(conf->drm_enabled, prev->drm_enabled, 0);
+	ngx_conf_merge_value(conf->drm_single_key, prev->drm_single_key, 0);
 	ngx_conf_merge_uint_value(conf->drm_clear_lead_segment_count, prev->drm_clear_lead_segment_count, 1);
 	ngx_conf_merge_str_value(conf->drm_upstream_location, prev->drm_upstream_location, "");
 	ngx_conf_merge_size_value(conf->drm_max_info_length, prev->drm_max_info_length, 4096);
@@ -1135,6 +1137,13 @@ ngx_command_t ngx_http_vod_commands[] = {
 	ngx_conf_set_flag_slot,
 	NGX_HTTP_LOC_CONF_OFFSET,
 	offsetof(ngx_http_vod_loc_conf_t, drm_enabled),
+	NULL },
+
+	{ ngx_string("vod_drm_single_key"),
+	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+	ngx_conf_set_flag_slot,
+	NGX_HTTP_LOC_CONF_OFFSET,
+	offsetof(ngx_http_vod_loc_conf_t, drm_single_key),
 	NULL },
 
 	{ ngx_string("vod_drm_clear_lead_segment_count"),

--- a/ngx_http_vod_conf.h
+++ b/ngx_http_vod_conf.h
@@ -72,6 +72,7 @@ struct ngx_http_vod_loc_conf_s {
 	ngx_array_t *last_modified_types_keys;
 
 	ngx_flag_t drm_enabled;
+	ngx_flag_t drm_single_key;
 	ngx_uint_t drm_clear_lead_segment_count;
 	ngx_str_t drm_upstream_location;
 	size_t drm_max_info_length;

--- a/ngx_http_vod_dash_commands.h
+++ b/ngx_http_vod_dash_commands.h
@@ -7,6 +7,13 @@
 	BASE_OFFSET + offsetof(ngx_http_vod_dash_loc_conf_t, absolute_manifest_urls),
 	NULL },
 	
+	{ ngx_string("vod_dash_init_mp4_pssh"),
+	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+	ngx_conf_set_flag_slot,
+	NGX_HTTP_LOC_CONF_OFFSET,
+	BASE_OFFSET + offsetof(ngx_http_vod_dash_loc_conf_t, init_mp4_pssh),
+	NULL },
+
 	{ ngx_string("vod_dash_manifest_file_name_prefix"),
 	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
 	ngx_conf_set_str_slot,
@@ -56,4 +63,11 @@
 	BASE_OFFSET + offsetof(ngx_http_vod_dash_loc_conf_t, mpd_config.duplicate_bitrate_threshold),
 	NULL },
 	
+	{ ngx_string("vod_dash_write_playready_kid"),
+	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+	ngx_conf_set_flag_slot,
+	NGX_HTTP_LOC_CONF_OFFSET,
+	BASE_OFFSET + offsetof(ngx_http_vod_dash_loc_conf_t, mpd_config.write_playready_kid),
+	NULL },
+
 #undef BASE_OFFSET

--- a/ngx_http_vod_dash_conf.h
+++ b/ngx_http_vod_dash_conf.h
@@ -10,6 +10,7 @@ typedef struct
 {
 	ngx_str_t manifest_file_name_prefix;
 	ngx_flag_t absolute_manifest_urls;
+	ngx_flag_t init_mp4_pssh;
 	dash_manifest_config_t mpd_config;
 } ngx_http_vod_dash_loc_conf_t;
 

--- a/vod/dash/dash_packager.h
+++ b/vod/dash/dash_packager.h
@@ -31,13 +31,25 @@ typedef struct {
 } atom_writer_t;
 
 typedef struct {
+	size_t size;
+	write_tags_callback_t write;
+	void* context;
+} tags_writer_t;
+
+typedef struct {
 	vod_str_t profiles;
 	vod_str_t init_file_name_prefix;
 	vod_str_t fragment_file_name_prefix;
 	vod_str_t subtitle_file_name_prefix;
 	vod_uint_t manifest_format;
 	vod_uint_t duplicate_bitrate_threshold;
+	bool_t write_playready_kid;		// TODO: remove
 } dash_manifest_config_t;
+
+typedef struct {
+	tags_writer_t representation;
+	tags_writer_t adaptation_set;
+} dash_manifest_extensions_t;
 
 typedef struct {
 	size_t extra_traf_atoms_size;
@@ -51,9 +63,7 @@ vod_status_t dash_packager_build_mpd(
 	dash_manifest_config_t* conf,
 	vod_str_t* base_url,
 	media_set_t* media_set,
-	size_t representation_tags_size,
-	write_tags_callback_t write_representation_tags,
-	void* representation_tags_writer_context,
+	dash_manifest_extensions_t* extensions,
 	vod_str_t* result);
 
 vod_status_t dash_packager_build_init_mp4(

--- a/vod/dash/edash_packager.h
+++ b/vod/dash/edash_packager.h
@@ -4,18 +4,23 @@
 // includes
 #include "dash_packager.h"
 
+// constants
+#define EDASH_INIT_MP4_HAS_CLEAR_LEAD	(0x01)
+#define EDASH_INIT_MP4_WRITE_PSSH		(0x02)
+
 // functions
 vod_status_t edash_packager_build_mpd(
 	request_context_t* request_context,
 	dash_manifest_config_t* conf,
 	vod_str_t* base_url,
 	media_set_t* media_set,
+	bool_t drm_single_key,
 	vod_str_t* result);
 
 vod_status_t edash_packager_build_init_mp4(
 	request_context_t* request_context,
 	media_set_t* media_set,
-	bool_t has_clear_lead,
+	uint32_t flags,
 	bool_t size_only,
 	vod_str_t* result);
 


### PR DESCRIPTION
- add vod_drm_single_key
- add vod_dash_init_mp4_pssh
- add default_KID attribute to PlayReady ContentProtection (temporarily
  configurable, in the future will probably always be enabled)