### PR TITLE
fix handling of small webvtt files in remote mode

### DIFF
--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -1550,6 +1550,7 @@ ngx_http_vod_identify_format(ngx_http_vod_ctx_t* ctx)
 		rc = cur_format->init_metadata_reader(
 			&ctx->submodule_context.request_context,
 			&buffer,
+			ctx->submodule_context.conf->initial_read_size,
 			ctx->submodule_context.conf->max_metadata_size,
 			&ctx->metadata_reader_context);
 		if (rc == VOD_NOT_FOUND)

--- a/vod/media_format.h
+++ b/vod/media_format.h
@@ -266,6 +266,7 @@ typedef struct {
 	vod_status_t(*init_metadata_reader)(
 		request_context_t* request_context, 
 		vod_str_t* buffer,
+		size_t initial_read_size,
 		size_t max_metadata_size,
 		void** ctx);
 

--- a/vod/mkv/mkv_format.c
+++ b/vod/mkv/mkv_format.c
@@ -299,6 +299,7 @@ static vod_status_t
 mkv_metadata_reader_init(
 	request_context_t* request_context,
 	vod_str_t* buffer,
+	size_t initial_read_size,
 	size_t max_metadata_size,
 	void** ctx)
 {

--- a/vod/mp4/mp4_format.c
+++ b/vod/mp4/mp4_format.c
@@ -41,6 +41,7 @@ static vod_status_t
 mp4_metadata_reader_init(
 	request_context_t* request_context, 
 	vod_str_t* buffer, 
+	size_t initial_read_size,
 	size_t max_metadata_size,
 	void** ctx)
 {

--- a/vod/webvtt/webvtt_format.c
+++ b/vod/webvtt/webvtt_format.c
@@ -11,6 +11,7 @@
 
 // typedefs
 typedef struct {
+	size_t initial_read_size;
 	size_t size_limit;
 	bool_t first_time;
 	vod_str_t buffer;
@@ -145,6 +146,7 @@ static vod_status_t
 webvtt_reader_init(
 	request_context_t* request_context,
 	vod_str_t* buffer,
+	size_t initial_read_size,
 	size_t max_metadata_size,
 	void** ctx)
 {
@@ -173,6 +175,7 @@ webvtt_reader_init(
 
 	state->first_time = TRUE;
 	state->size_limit = 2 * 1024 * 1024;			// XXXXX support configuring different metadata size limits per format
+	state->initial_read_size = initial_read_size;
 
 	*ctx = state;
 	return VOD_OK;
@@ -187,7 +190,7 @@ webvtt_reader_read(
 {
 	webvtt_reader_state_t* state = ctx;
 
-	if (!state->first_time)
+	if (buffer->len < state->initial_read_size || !state->first_time)
 	{
 		state->buffer = *buffer;
 		result->parts = &state->buffer;


### PR DESCRIPTION
1. need to treat error 416 as a successful empty read
2. for cases in which the initial read completes with a size smaller than the requested size, no need to perform the second read