### PR TITLE
skip zero padding for sample aes

### DIFF
--- a/vod/hls/mp4_to_annexb_filter.c
+++ b/vod/hls/mp4_to_annexb_filter.c
@@ -269,7 +269,7 @@ mp4_to_annexb_flush_frame(void* context, bool_t last_stream_frame)
 	vod_status_t rc;
 	int32_t cur_size;
 
-	if (state->nal_packet_size_length == 4)
+	if (state->nal_packet_size_length == 4 && state->sample_aes_context == NULL)
 	{
 		if (state->frame_size_left < 0)
 		{


### PR DESCRIPTION
cannot just zero pad the packet, the zeros have to go through emulation prevention (\0\0\0 -> \0\0\x03\0) however, since in sample aes the packet size is not known in advance anyway, we can just skip it.