### PR TITLE
add -x3 suffix only to video/audio streams

### DIFF
--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -485,13 +485,14 @@ dash_packager_get_track_spec(
 	{
 	case MEDIA_TYPE_VIDEO:
 		p = vod_sprintf(p, "v%uD", track_index + 1);
+		p = vod_copy(p, "-x3", sizeof("-x3") - 1);		// TODO: remove this after deployment
 		break;
 
 	case MEDIA_TYPE_AUDIO:
 		p = vod_sprintf(p, "a%uD", track_index + 1);
+		p = vod_copy(p, "-x3", sizeof("-x3") - 1);		// TODO: remove this after deployment
 		break;
 	}
-	p = vod_copy(p, "-x3", sizeof("-x3") - 1);		// TODO: remove this after deployment
 
 	result->len = p - result->data;
 }


### PR DESCRIPTION
creates an invalid url for captions (e.g. sub-f1--x3)