### PR TITLE
Add manifest duration policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,6 +842,15 @@ Configures the policy for calculating the segment count, for segment_duration = 
 * last_long - a file of 33 sec is partitioned as - 10, 10, 13
 * last_rounded - a file of 33 sec is partitioned as - 10, 10, 13, a file of 38 sec is partitioned as 10, 10, 10, 8
 
+#### vod_manifest_duration_policy
+* **syntax**: `vod_manifest_duration_policy min/max`
+* **default**: `max`
+* **context**: `http`, `server`, `location`
+
+Configures the policy for calculating the duration of a manifest containing multiple streams:
+* max - uses the maximum stream duration (default)
+* min - uses the minimum non-zero stream duration
+
 #### vod_manifest_segment_durations_mode
 * **syntax**: `vod_manifest_segment_durations_mode estimate/accurate`
 * **default**: `estimate`

--- a/ngx_http_vod_conf.c
+++ b/ngx_http_vod_conf.c
@@ -73,6 +73,7 @@ ngx_http_vod_create_loc_conf(ngx_conf_t *cf)
 	conf->segmenter.align_to_key_frames = NGX_CONF_UNSET;
 	conf->segmenter.get_segment_count = NGX_CONF_UNSET_PTR;
 	conf->segmenter.get_segment_durations = NGX_CONF_UNSET_PTR;
+	conf->segmenter.manifest_duration_policy = NGX_CONF_UNSET_UINT;
 	conf->segmenter.gop_look_ahead = NGX_CONF_UNSET_UINT;
 	conf->segmenter.gop_look_behind = NGX_CONF_UNSET_UINT;
 	conf->force_continuous_timestamps = NGX_CONF_UNSET;
@@ -152,6 +153,7 @@ ngx_http_vod_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 	ngx_conf_merge_value(conf->segmenter.align_to_key_frames, prev->segmenter.align_to_key_frames, 0);
 	ngx_conf_merge_ptr_value(conf->segmenter.get_segment_count, prev->segmenter.get_segment_count, segmenter_get_segment_count_last_short);
 	ngx_conf_merge_ptr_value(conf->segmenter.get_segment_durations, prev->segmenter.get_segment_durations, segmenter_get_segment_durations_estimate);
+	ngx_conf_merge_uint_value(conf->segmenter.manifest_duration_policy, prev->segmenter.manifest_duration_policy, MDP_MAX);
 	ngx_conf_merge_uint_value(conf->segmenter.gop_look_ahead, prev->segmenter.gop_look_ahead, 1000);
 	ngx_conf_merge_uint_value(conf->segmenter.gop_look_behind, prev->segmenter.gop_look_behind, 10000);
 	ngx_conf_merge_value(conf->force_continuous_timestamps, prev->force_continuous_timestamps, 0);
@@ -792,6 +794,12 @@ ngx_http_vod_status(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 	return NGX_CONF_OK;
 }
 
+static ngx_conf_enum_t manifest_duration_policies[] = {
+	{ ngx_string("max"), MDP_MAX },
+	{ ngx_string("min"), MDP_MIN },
+	{ ngx_null_string, 0 }
+};
+
 ngx_command_t ngx_http_vod_commands[] = {
 
 	// basic parameters
@@ -872,6 +880,13 @@ ngx_command_t ngx_http_vod_commands[] = {
 	NGX_HTTP_LOC_CONF_OFFSET,
 	0,
 	NULL },
+
+	{ ngx_string("vod_manifest_duration_policy"),
+	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+	ngx_conf_set_enum_slot,
+	NGX_HTTP_LOC_CONF_OFFSET,
+	offsetof(ngx_http_vod_loc_conf_t, segmenter.manifest_duration_policy),
+	manifest_duration_policies },
 
 	{ ngx_string("vod_manifest_segment_durations_mode"),
 	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,

--- a/vod/filters/filter.c
+++ b/vod/filters/filter.c
@@ -259,6 +259,8 @@ filter_init_filtered_clips(
 	media_clip_t* input_clip;
 	media_track_t* new_track;
 	uint32_t track_count[MEDIA_TYPE_COUNT];
+	uint32_t min_media_type;
+	uint32_t max_media_type;
 	uint32_t total_duration;
 	uint32_t clip_index;
 	uint32_t media_type;
@@ -457,18 +459,27 @@ filter_init_filtered_clips(
 	if (media_set->timing.durations == NULL)
 	{
 		// set the total duration
+		if (media_set->track_count[MEDIA_TYPE_VIDEO] + media_set->track_count[MEDIA_TYPE_AUDIO] > 0)
+		{
+			min_media_type = 0;
+			max_media_type = MEDIA_TYPE_SUBTITLE;
+		}
+		else
+		{
+			min_media_type = MEDIA_TYPE_SUBTITLE;
+			max_media_type = MEDIA_TYPE_COUNT;
+		}
+
 		total_duration = 0;
 
 		switch (init_state.manifest_duration_policy)
 		{
 		case MDP_MAX:
-			for (sequence = media_set->sequences;
-				sequence < media_set->sequences_end;
-				sequence++)
+			for (sequence = media_set->sequences; sequence < media_set->sequences_end; sequence++)
 			{
 				output_clip = &sequence->filtered_clips[0];
 
-				for (media_type = 0; media_type < MEDIA_TYPE_COUNT; media_type++)
+				for (media_type = min_media_type; media_type < max_media_type; media_type++)
 				{
 					if (output_clip->ref_track[media_type] == NULL)
 					{
@@ -484,13 +495,11 @@ filter_init_filtered_clips(
 			break;
 
 		case MDP_MIN:
-			for (sequence = media_set->sequences;
-				sequence < media_set->sequences_end;
-				sequence++)
+			for (sequence = media_set->sequences; sequence < media_set->sequences_end; sequence++)
 			{
 				output_clip = &sequence->filtered_clips[0];
 
-				for (media_type = 0; media_type < MEDIA_TYPE_COUNT; media_type++)
+				for (media_type = min_media_type; media_type < max_media_type; media_type++)
 				{
 					if (output_clip->ref_track[media_type] == NULL)
 					{

--- a/vod/hls/hls_muxer.c
+++ b/vod/hls/hls_muxer.c
@@ -347,9 +347,22 @@ hls_muxer_init_base(
 		switch (track->media_info.media_type)
 		{
 		case MEDIA_TYPE_VIDEO:
-			if (track->media_info.duration_millis > state->video_duration)
+			switch (media_set->segmenter_conf->manifest_duration_policy)
 			{
-				state->video_duration = track->media_info.duration_millis;
+			case MDP_MAX:
+				if (track->media_info.duration_millis > state->video_duration)
+				{
+					state->video_duration = track->media_info.duration_millis;
+				}
+				break;
+
+			case MDP_MIN:
+				if (track->media_info.duration_millis > 0 &&
+					(state->video_duration == 0 || track->media_info.duration_millis < state->video_duration))
+				{
+					state->video_duration = track->media_info.duration_millis;
+				}
+				break;
 			}
 
 			rc = mp4_to_annexb_init(

--- a/vod/manifest_utils.c
+++ b/vod/manifest_utils.c
@@ -784,7 +784,7 @@ manifest_utils_get_muxed_adaptation_set(
 		}
 
 		// find the audio track
-		audio_track = cur_sequence->filtered_clips[0].longest_track[MEDIA_TYPE_AUDIO];
+		audio_track = cur_sequence->filtered_clips[0].ref_track[MEDIA_TYPE_AUDIO];
 		if ((audio_track == NULL || (label != NULL && !vod_str_equals(*label, audio_track->media_info.label))) &&
 			media_set->track_count[MEDIA_TYPE_AUDIO] > 0)
 		{

--- a/vod/media_set.h
+++ b/vod/media_set.h
@@ -41,7 +41,7 @@ typedef struct {
 typedef struct {
 	media_track_t* first_track;
 	media_track_t* last_track;
-	media_track_t* longest_track[MEDIA_TYPE_COUNT];
+	media_track_t* ref_track[MEDIA_TYPE_COUNT];		// either longest or shortest, depending on segmenter conf
 } media_clip_filtered_t;
 
 struct media_sequence_s {

--- a/vod/segmenter.c
+++ b/vod/segmenter.c
@@ -1540,7 +1540,7 @@ segmenter_get_segment_durations_estimate_internal(
 	return VOD_OK;
 }
 
-static uint64_t
+uint64_t
 segmenter_get_total_duration(
 	segmenter_conf_t* conf,
 	media_set_t* media_set,

--- a/vod/segmenter.h
+++ b/vod/segmenter.h
@@ -115,6 +115,14 @@ vod_status_t segmenter_get_live_window(
 	bool_t parse_all_clips,
 	get_clip_ranges_result_t* clip_ranges);
 
+// manifest duration
+uint64_t segmenter_get_total_duration(
+	segmenter_conf_t* conf,
+	media_set_t* media_set,
+	media_sequence_t* sequence,
+	media_sequence_t* sequences_end,
+	uint32_t media_type);
+
 // get segment durations modes
 vod_status_t segmenter_get_segment_durations_estimate(
 	request_context_t* request_context,

--- a/vod/segmenter.h
+++ b/vod/segmenter.h
@@ -69,6 +69,11 @@ typedef vod_status_t (*segmenter_get_segment_durations_t)(
 	uint32_t media_type,
 	segment_durations_t* result);
 
+enum {
+	MDP_MAX,
+	MDP_MIN,
+};
+
 struct segmenter_conf_s {
 	// config fields
 	uintptr_t segment_duration;
@@ -77,6 +82,7 @@ struct segmenter_conf_s {
 	intptr_t live_window_duration;
 	segmenter_get_segment_count_t get_segment_count;			// last short / last long / last rounded
 	segmenter_get_segment_durations_t get_segment_durations;	// estimate / accurate
+	vod_uint_t manifest_duration_policy;
 	uintptr_t gop_look_behind;
 	uintptr_t gop_look_ahead;
 


### PR DESCRIPTION
reporting the maximum stream duration can cause issues in dash when the video/audio duration is different - if the duration difference crosses segment boundary, the last segment(s) of the short stream will return an error.