### PR TITLE
Add arguments to index and chunk responses.

### DIFF
--- a/ngx_http_vod_hls.c
+++ b/ngx_http_vod_hls.c
@@ -112,6 +112,7 @@ ngx_http_vod_hls_handle_master_playlist(
 		&conf->hls.m3u8_config,
 		conf->hls.encryption_method,
 		&base_url,
+		&submodule_context->r->args,
 		&submodule_context->media_set,
 		response);
 	if (rc != VOD_OK)
@@ -192,6 +193,7 @@ ngx_http_vod_hls_handle_index_playlist(
 		&submodule_context->request_context,
 		&conf->hls.m3u8_config,
 		&base_url,
+		&submodule_context->r->args,
 		&segments_base_url,
 		&submodule_context->request_params,
 		&encryption_params,

--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -1014,7 +1014,8 @@ m3u8_builder_build_master_playlist(
 				&conf->iframes_file_name_prefix,
 				media_set,
 				tracks,
-				base_url);
+				base_url,
+				args);
 
 			*p++ = '\"';
 			*p++ = '\n';

--- a/vod/hls/m3u8_builder.h
+++ b/vod/hls/m3u8_builder.h
@@ -30,6 +30,7 @@ vod_status_t m3u8_builder_build_master_playlist(
 	m3u8_config_t* conf,
 	vod_uint_t encryption_method,
 	vod_str_t* base_url,
+	vod_str_t* args,
 	media_set_t* media_set,
 	vod_str_t* result);
 
@@ -37,6 +38,7 @@ vod_status_t m3u8_builder_build_index_playlist(
 	request_context_t* request_context,
 	m3u8_config_t* conf,
 	vod_str_t* base_url,
+	vod_str_t* args,
 	vod_str_t* segments_base_url,
 	request_params_t* request_params,
 	hls_encryption_params_t* encryption_params,


### PR DESCRIPTION
In combination with **secure_link** module and arguments in the URL, it is possible to use temporary URL's with HLS. By default, nginx-vod-module does not add arguments to segments, so the segments cannot be verified. This patch will copy the original arguments to all segment URL's.

Example configuration:

```
set $secure_secret "foobar";
location / {
	return 400;
}
location ~ "^(?<basepath>.+)/.+\.(m3u8|ts)$" {
	root /web/;
	vod hls;
			
	add_header Access-Control-Allow-Headers '*';
	add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
	add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';
	add_header Access-Control-Allow-Origin '*';
	expires 100d;

	secure_link $arg_hmac,$arg_expires;
	secure_link_md5 $secure_secret$basepath$arg_expires;

	# Invalid
	if ($secure_link = "") {
		return 403;
	}
	# Expired
	if ($secure_link = 0) {
		return 410;
	}
}
```

We needed this at our company. Some people have talked about it here as well (#87).

If this is of no use, feel free to ignore :)