### PR TITLE
misc fixes

### DIFF
--- a/ngx_buffer_cache.c
+++ b/ngx_buffer_cache.c
@@ -448,7 +448,7 @@ ngx_buffer_cache_store_gather(
 	}
 
 	// allocate a buffer to hold the data
-	target_buffer = ngx_buffer_cache_get_free_buffer(sh, buffer_size);
+	target_buffer = ngx_buffer_cache_get_free_buffer(sh, buffer_size + 1);
 	if (target_buffer == NULL)
 	{
 		goto error;
@@ -487,6 +487,7 @@ ngx_buffer_cache_store_gather(
 	{
 		target_buffer = ngx_copy(target_buffer, cur_buffer->data, cur_buffer->len);
 	}
+	*target_buffer = '\0';
 
 	// Note: no need to obtain the lock since state is ngx_atomic_t
 	entry->state = CES_READY;

--- a/vod/common.h
+++ b/vod/common.h
@@ -19,6 +19,9 @@
 #define vod_is_bit_set(mask, index) (((mask)[(index) >> 3] >> ((index) & 7)) & 1)
 #define vod_set_bit(mask, index) (mask)[(index) >> 3] |= 1 << ((index) & 7)
 
+#define vod_no_flag_set(mask, f) (((mask) & (f)) == 0)
+#define vod_all_flags_set(mask, f) (((mask) & (f)) == (f))
+
 // Note: comparing the pointers since in the case of labels if both were derived by the language, 
 //		they will have the same pointer and we can skip the memcmp
 #define vod_str_equals(l1, l2) \

--- a/vod/manifest_utils.c
+++ b/vod/manifest_utils.c
@@ -1,9 +1,5 @@
 #include "manifest_utils.h"
 
-// macros
-#define no_flag_set(mask, f) (((mask) & (f)) == 0)
-#define all_flags_set(mask, f) (((mask) & (f)) == (f))
-
 // internal flags
 #define ADAPTATION_SETS_FLAG_MULTI_AUDIO		(0x1000)
 #define ADAPTATION_SETS_FLAG_IGNORE_SUBTITLES	(0x2000)
@@ -555,7 +551,7 @@ track_group_add_track(
 		return;
 
 	case MEDIA_TYPE_AUDIO:
-		if (all_flags_set(flags, ADAPTATION_SETS_FLAG_MULTI_AUDIO | ADAPTATION_SETS_FLAG_SINGLE_LANG_TRACK))
+		if (vod_all_flags_set(flags, ADAPTATION_SETS_FLAG_MULTI_AUDIO | ADAPTATION_SETS_FLAG_SINGLE_LANG_TRACK))
 		{
 			return;
 		}
@@ -954,7 +950,7 @@ manifest_utils_get_adaptation_sets(
 	}
 
 	if ((flags & ADAPTATION_SETS_FLAG_MULTI_AUDIO) != 0 ||
-		no_flag_set(flags, ADAPTATION_SETS_FLAG_MUXED | ADAPTATION_SETS_FLAG_FORCE_MUXED))
+		vod_no_flag_set(flags, ADAPTATION_SETS_FLAG_MUXED | ADAPTATION_SETS_FLAG_FORCE_MUXED))
 	{
 		// if multi audio or not muxed, output unmuxed
 		rc = track_groups_from_media_set(
@@ -968,7 +964,7 @@ manifest_utils_get_adaptation_sets(
 			return rc;
 		}
 
-		if (all_flags_set(flags, ADAPTATION_SETS_FLAG_MULTI_AUDIO | ADAPTATION_SETS_FLAG_DEFAULT_LANG_LAST))
+		if (vod_all_flags_set(flags, ADAPTATION_SETS_FLAG_MULTI_AUDIO | ADAPTATION_SETS_FLAG_DEFAULT_LANG_LAST))
 		{
 			vod_queue_t* first = vod_queue_head(&groups[MEDIA_TYPE_AUDIO].list);
 			vod_queue_remove(first);

--- a/vod/mp4/mp4_parser.c
+++ b/vod/mp4/mp4_parser.c
@@ -3166,7 +3166,8 @@ mp4_parser_parse_frames(
 		result_track->source_clip = NULL;
 
 		// update the last offset of the source clip
-		if (context.frame_count > 0)
+		if (context.frame_count > 0 && 
+			vod_all_flags_set(parse_params->parse_type, PARSE_FLAG_FRAMES_SIZE | PARSE_FLAG_FRAMES_OFFSET))
 		{
 			last_frame = result_track->frames.last_frame - 1;
 			last_offset = last_frame->offset + last_frame->size;


### PR DESCRIPTION
- when returning metadata from cache, it may not be null terminated, while dfxp_format assumes it is
- update last_offset only parsing frame size and offset, otherwise valgrind complains about access to uninitialized vars