### PR TITLE
cache fetch optimization

### DIFF
--- a/ngx_buffer_cache.c
+++ b/ngx_buffer_cache.c
@@ -323,8 +323,7 @@ ngx_flag_t
 ngx_buffer_cache_fetch(
 	ngx_buffer_cache_t* cache,
 	u_char* key,
-	u_char** buffer,
-	size_t* buffer_size)
+	ngx_str_t* buffer)
 {
 	ngx_buffer_cache_entry_t* entry;
 	ngx_buffer_cache_sh_t *sh = cache->sh;
@@ -348,8 +347,8 @@ ngx_buffer_cache_fetch(
 			sh->stats.fetch_bytes += entry->buffer_size;
 
 			// copy buffer pointer and size
-			*buffer = entry->start_offset;
-			*buffer_size = entry->buffer_size;
+			buffer->data = entry->start_offset;
+			buffer->len = entry->buffer_size;
 
 			// Note: setting the access time of the entry and cache to prevent it 
 			//		from being freed while the caller uses the buffer

--- a/ngx_buffer_cache.h
+++ b/ngx_buffer_cache.h
@@ -32,8 +32,7 @@ typedef struct {
 ngx_flag_t ngx_buffer_cache_fetch(
 	ngx_buffer_cache_t* cache,
 	u_char* key,
-	u_char** buffer,
-	size_t* buffer_size);
+	ngx_str_t* buffer);
 
 ngx_flag_t ngx_buffer_cache_store(
 	ngx_buffer_cache_t* cache,

--- a/test/buffer_cache/main.c
+++ b/test/buffer_cache/main.c
@@ -156,7 +156,7 @@ int run_test_cycle(time_t seed, size_t cache_size, int iterations, int size_fact
 {
 	ngx_buffer_cache_stats_t stats;
 	u_char key[BUFFER_CACHE_KEY_SIZE];
-	u_char* fetch_buffer;
+	ngx_str_t fetch_buffer;
 	u_char* store_buffer;
 	size_t* sizes_buffer;
 	size_t size;
@@ -230,15 +230,15 @@ int run_test_cycle(time_t seed, size_t cache_size, int iterations, int size_fact
 		for (j = min_existing_index; j <= i; j++)
 		{
 			((uint32_t*)&key)[0] = j;
-			if (ngx_buffer_cache_fetch(cache, key, &fetch_buffer, &size))
+			if (ngx_buffer_cache_fetch(cache, key, &fetch_buffer))
 			{
-				if (sizes_buffer[j] != size)
+				if (sizes_buffer[j] != fetch_buffer.len)
 				{
 					printf("Error: invalid buffer size\n");
 					return 0;
 				}
 				
-				if (!validate_random_buffer(j, fetch_buffer, size))
+				if (!validate_random_buffer(j, fetch_buffer.data, fetch_buffer.len))
 				{
 					printf("Error: invalid buffer content\n");
 					return 0;


### PR DESCRIPTION
no need to copy the buffer when reading from drm/mapping cache. when parsing a json, the strings values/keys keep a pointer to the original buffer, but in all cases when the string is retained, it is
copied.
also, no need to save the mapping cache with a null terminator since that is already handled by the buffer cache