### PR TITLE
multi audio codec fix

### DIFF
--- a/vod/dash/dash_packager.c
+++ b/vod/dash/dash_packager.c
@@ -935,7 +935,7 @@ dash_packager_write_mpd_period(
 
 		case MEDIA_TYPE_AUDIO:
 			reference_track = (*adaptation_set->first) + filtered_clip_offset;
-			if (context->adaptation_sets.count[ADAPTATION_TYPE_AUDIO] > 1)
+			if (context->adaptation_sets.multi_audio)
 			{
 				p = vod_sprintf(p, VOD_DASH_MANIFEST_ADAPTATION_HEADER_AUDIO_LANG, 
 					adapt_id++, lang_get_iso639_1_name(reference_track->media_info.language));

--- a/vod/hds/hds_manifest.c
+++ b/vod/hds/hds_manifest.c
@@ -696,7 +696,7 @@ hds_packager_build_manifest(
 			else
 			{
 				bitrate = tracks[MEDIA_TYPE_AUDIO]->media_info.bitrate;
-				if (adaptation_sets.total_count > 1 && adaptation_set > adaptation_sets.first)
+				if (adaptation_sets.multi_audio && adaptation_set > adaptation_sets.first)
 				{
 					p = vod_sprintf(p, HDS_MEDIA_HEADER_PREFIX_AUDIO_LANG,
 						bitrate / 1000, 

--- a/vod/manifest_utils.c
+++ b/vod/manifest_utils.c
@@ -942,6 +942,11 @@ manifest_utils_get_adaptation_sets(
 	if (manifest_utils_is_multi_audio(media_set))
 	{
 		flags |= ADAPTATION_SETS_FLAG_MULTI_AUDIO;
+		output->multi_audio = TRUE;
+	}
+	else
+	{
+		output->multi_audio = FALSE;
 	}
 
 	if (media_set->track_count[MEDIA_TYPE_VIDEO] <= 0)

--- a/vod/manifest_utils.h
+++ b/vod/manifest_utils.h
@@ -37,6 +37,7 @@ typedef struct {
 	adaptation_set_t* first_by_type[ADAPTATION_TYPE_COUNT];
 	uint32_t count[ADAPTATION_TYPE_COUNT];
 	uint32_t total_count;
+	bool_t multi_audio;
 } adaptation_sets_t;
 
 // functions

--- a/vod/mss/mss_packager.c
+++ b/vod/mss/mss_packager.c
@@ -498,7 +498,7 @@ mss_packager_build_manifest(
 		switch (media_type)
 		{
 		case MEDIA_TYPE_AUDIO:
-			if (adaptation_sets.count[ADAPTATION_TYPE_AUDIO] > 1)
+			if (adaptation_sets.multi_audio)
 			{
 				cur_track = *adaptation_set->first;
 				p = vod_sprintf(p,


### PR DESCRIPTION
do not assume that multiple audio tracks = multiple languages, in case of multiple codecs this can result in lang="un" in the manifest