### PR TITLE
Add hls diretive vod_hls_query_args

### DIFF
--- a/ngx_http_vod_hls.c
+++ b/ngx_http_vod_hls.c
@@ -113,7 +113,8 @@ ngx_http_vod_hls_handle_master_playlist(
 		conf->hls.encryption_method,
 		&base_url,
 		&submodule_context->media_set,
-		response);
+		response,
+		&submodule_context->r->args);
 	if (rc != VOD_OK)
 	{
 		ngx_log_debug1(NGX_LOG_DEBUG_HTTP, submodule_context->request_context.log, 0,
@@ -196,7 +197,8 @@ ngx_http_vod_hls_handle_index_playlist(
 		&submodule_context->request_params,
 		&encryption_params,
 		&submodule_context->media_set,
-		response);
+		response,
+        &submodule_context->r->args);
 	if (rc != VOD_OK)
 	{
 		ngx_log_debug1(NGX_LOG_DEBUG_HTTP, submodule_context->request_context.log, 0,
@@ -452,7 +454,7 @@ ngx_http_vod_hls_merge_loc_conf(
 	ngx_conf_merge_str_value(conf->m3u8_config.iframes_file_name_prefix, prev->m3u8_config.iframes_file_name_prefix, "iframes");
 	ngx_conf_merge_str_value(conf->m3u8_config.segment_file_name_prefix, prev->m3u8_config.segment_file_name_prefix, "seg");
 
-	ngx_conf_merge_value(conf->m3u8_config.query_args, prev->m3u8_config.query_args, 0);
+    ngx_conf_merge_value(conf->m3u8_config.query_args, prev->m3u8_config.query_args, 0);
 
 	ngx_conf_merge_str_value(conf->m3u8_config.encryption_key_file_name, prev->m3u8_config.encryption_key_file_name, "encryption");
 	ngx_conf_merge_str_value(conf->m3u8_config.encryption_key_format, prev->m3u8_config.encryption_key_format, "");

--- a/ngx_http_vod_hls.c
+++ b/ngx_http_vod_hls.c
@@ -433,6 +433,7 @@ ngx_http_vod_hls_create_loc_conf(
 	conf->muxer_config.align_frames = NGX_CONF_UNSET;
 	conf->muxer_config.output_id3_timestamps = NGX_CONF_UNSET;
 	conf->encryption_method = NGX_CONF_UNSET_UINT;
+	conf->m3u8_config.query_args = NGX_CONF_UNSET;
 }
 
 static char *
@@ -450,6 +451,8 @@ ngx_http_vod_hls_merge_loc_conf(
 	ngx_conf_merge_str_value(conf->m3u8_config.index_file_name_prefix, prev->m3u8_config.index_file_name_prefix, "index");	
 	ngx_conf_merge_str_value(conf->m3u8_config.iframes_file_name_prefix, prev->m3u8_config.iframes_file_name_prefix, "iframes");
 	ngx_conf_merge_str_value(conf->m3u8_config.segment_file_name_prefix, prev->m3u8_config.segment_file_name_prefix, "seg");
+
+	ngx_conf_merge_value(conf->m3u8_config.query_args, prev->m3u8_config.query_args, 0);
 
 	ngx_conf_merge_str_value(conf->m3u8_config.encryption_key_file_name, prev->m3u8_config.encryption_key_file_name, "encryption");
 	ngx_conf_merge_str_value(conf->m3u8_config.encryption_key_format, prev->m3u8_config.encryption_key_format, "");

--- a/ngx_http_vod_hls_commands.h
+++ b/ngx_http_vod_hls_commands.h
@@ -106,5 +106,12 @@
 	NGX_HTTP_LOC_CONF_OFFSET,
 	BASE_OFFSET + offsetof(ngx_http_vod_hls_loc_conf_t, muxer_config.output_id3_timestamps),
 	NULL },
+
+	{ ngx_string("vod_hls_query_args"),
+	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+	ngx_conf_set_flag_slot,
+	NGX_HTTP_LOC_CONF_OFFSET,
+	BASE_OFFSET + offsetof(ngx_http_vod_hls_loc_conf_t, m3u8_config.query_args),
+	NULL },
 	
 #undef BASE_OFFSET

--- a/ngx_http_vod_hls_commands.h
+++ b/ngx_http_vod_hls_commands.h
@@ -108,10 +108,10 @@
 	NULL },
 
 	{ ngx_string("vod_hls_query_args"),
-	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-	ngx_conf_set_flag_slot,
-	NGX_HTTP_LOC_CONF_OFFSET,
-	BASE_OFFSET + offsetof(ngx_http_vod_hls_loc_conf_t, m3u8_config.query_args),
-	NULL },
+    NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+    ngx_conf_set_flag_slot,
+    NGX_HTTP_LOC_CONF_OFFSET,
+    BASE_OFFSET + offsetof(ngx_http_vod_hls_loc_conf_t, m3u8_config.query_args),
+    NULL },
 	
 #undef BASE_OFFSET

--- a/vod/hls/m3u8_builder.h
+++ b/vod/hls/m3u8_builder.h
@@ -22,6 +22,7 @@ typedef struct {
 	vod_str_t encryption_key_file_name;
 	vod_str_t encryption_key_format;
 	vod_str_t encryption_key_format_versions;
+	ngx_flag_t query_args;
 } m3u8_config_t;
 
 // functions

--- a/vod/hls/m3u8_builder.h
+++ b/vod/hls/m3u8_builder.h
@@ -32,7 +32,8 @@ vod_status_t m3u8_builder_build_master_playlist(
 	vod_uint_t encryption_method,
 	vod_str_t* base_url,
 	media_set_t* media_set,
-	vod_str_t* result);
+	vod_str_t* result,
+	vod_str_t* query_args);
 
 vod_status_t m3u8_builder_build_index_playlist(
 	request_context_t* request_context,
@@ -42,7 +43,8 @@ vod_status_t m3u8_builder_build_index_playlist(
 	request_params_t* request_params,
 	hls_encryption_params_t* encryption_params,
 	media_set_t* media_set,
-	vod_str_t* result);
+	vod_str_t* result,
+	vod_str_t* query_args);
 
 vod_status_t m3u8_builder_build_iframe_playlist(
 	request_context_t* request_context,


### PR DESCRIPTION
vod_hls_query_args

syntax: vod_hls_query_args on/off
default: off
context: http, server, location

When enabled the server includes the requested GET parameters into the HLS segments.  