### PR TITLE
Fix NGX_HAVE_OPENSSL_EVP with builtin OpenSSL

### DIFF
--- a/config
+++ b/config
@@ -27,12 +27,15 @@ ngx_feature="OpenSSL EVP library"
 ngx_feature_name="NGX_HAVE_OPENSSL_EVP"
 ngx_feature_run=no
 ngx_feature_incs="#include <openssl/evp.h>"
-ngx_feature_path=
-ngx_feature_libs="$LIB_CRYPTO $NGX_LIBDL $LIB_PTHREAD"
 ngx_feature_test="EVP_CIPHER_CTX_new();"
 
-[ -d "$OPENSSL/.openssl/include" ] && ngx_feature_path="$OPENSSL/.openssl/include"
-[ -d "$OPENSSL/.openssl/lib"     ] && ngx_feature_libs="-L $OPENSSL/.openssl/lib $ngx_feature_libs"
+if [ -n "$OPENSSL" -a -d "$OPENSSL/.openssl" ]; then
+	ngx_feature_path="$OPENSSL/.openssl/include"
+	ngx_feature_libs="$OPENSSL/.openssl/lib/libcrypto.a $NGX_LIBDL"
+else
+	ngx_feature_path=
+	ngx_feature_libs="$LIB_CRYPTO $NGX_LIBDL $LIB_PTHREAD"
+fi
 
 . auto/feature
 


### PR DESCRIPTION
Bugfix: when Nginx is configured with "--with-openssl=..." option and system-wide headers are not installed, nginx-vod is compiled without vod_drm_xx support because NGX_HAVE_OPENSSL_EVP macro is not assigned.