### PR TITLE
single nalu segment index relative to clip

### DIFF
--- a/ngx_http_vod_dash.c
+++ b/ngx_http_vod_dash.c
@@ -192,7 +192,8 @@ ngx_http_vod_dash_mp4_init_frame_processor(
 			&submodule_context->request_context,
 			&submodule_context->media_set,
 			submodule_context->request_params.segment_index,
-			conf->min_single_nalu_per_frame_segment > 0 && submodule_context->request_params.segment_index >= conf->min_single_nalu_per_frame_segment - 1,
+			conf->min_single_nalu_per_frame_segment > 0 && 
+				submodule_context->media_set.initial_segment_clip_relative_index >= conf->min_single_nalu_per_frame_segment - 1,
 			segment_writer,
 			submodule_context->media_set.sequences[0].encryption_key,		// iv
 			size_only,

--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -1562,6 +1562,8 @@ ngx_http_vod_parse_metadata(
 				rc = segmenter_get_start_end_ranges_no_discontinuity(
 					&get_ranges_params,
 					&clip_ranges);
+
+				ctx->submodule_context.media_set.initial_segment_clip_relative_index = clip_ranges.clip_relative_segment_index;
 			}
 			else
 			{

--- a/vod/media_set_parser.c
+++ b/vod/media_set_parser.c
@@ -2159,6 +2159,8 @@ media_set_parse_json(
 
 				}
 			}
+
+			result->initial_segment_clip_relative_index = context.clip_ranges.clip_relative_segment_index;
 		}
 		else
 		{

--- a/vod/segmenter.h
+++ b/vod/segmenter.h
@@ -57,6 +57,7 @@ typedef struct {
 	uint64_t clip_time;
 	media_range_t* clip_ranges;
 	uint32_t clip_count;
+	uint32_t clip_relative_segment_index;
 } get_clip_ranges_result_t;
 
 typedef uint32_t (*segmenter_get_segment_count_t)(segmenter_conf_t* conf, uint64_t duration_millis);


### PR DESCRIPTION
make vod_min_single_nalu_per_frame_segment relative to the first clip segment. 
in case of playlist, the first segment of each video does not match the single nalu assumption.