### PR TITLE
fix offsets in hds trun atoms

### DIFF
--- a/vod/mss/mss_packager.c
+++ b/vod/mss/mss_packager.c
@@ -85,7 +85,7 @@ typedef struct {
 	u_char flags[3];
 	u_char track_id[4];
 	u_char default_sample_flags[4];
-} tfhd_atom_t;
+} mss_tfhd_atom_t;
 
 typedef struct {
 	uint64_t timestamp;
@@ -629,7 +629,7 @@ mss_packager_build_manifest(
 static u_char*
 mss_write_tfhd_atom(u_char* p, uint32_t track_id, uint32_t flags)
 {
-	size_t atom_size = ATOM_HEADER_SIZE + sizeof(tfhd_atom_t);
+	size_t atom_size = ATOM_HEADER_SIZE + sizeof(mss_tfhd_atom_t);
 
 	write_atom_header(p, atom_size, 't', 'f', 'h', 'd');
 	write_be32(p, 0x20);		// default sample flags
@@ -725,7 +725,7 @@ mss_packager_build_fragment_header(
 
 	traf_atom_size =
 		ATOM_HEADER_SIZE +
-		ATOM_HEADER_SIZE + sizeof(tfhd_atom_t) +
+		ATOM_HEADER_SIZE + sizeof(mss_tfhd_atom_t) +
 		trun_atom_size +
 		ATOM_HEADER_SIZE + sizeof(uuid_tfxd_atom_t) + 
 		extra_traf_atoms_size;

--- a/vod/subtitle/ttml_builder.c
+++ b/vod/subtitle/ttml_builder.c
@@ -36,7 +36,7 @@ typedef struct {
 	u_char track_id[4];
 	u_char default_sample_duration[4];
 	u_char default_sample_size[4];
-} tfhd_atom_t;
+} ttml_tfhd_atom_t;
 
 // globals
 static u_char trun_atom[] = {
@@ -54,7 +54,7 @@ static u_char sdtp_atom[] = {
 static u_char*
 ttml_write_tfhd_atom(u_char* p, uint32_t default_sample_duration, u_char** default_sample_size)
 {
-	size_t atom_size = ATOM_HEADER_SIZE + sizeof(tfhd_atom_t);
+	size_t atom_size = ATOM_HEADER_SIZE + sizeof(ttml_tfhd_atom_t);
 
 	write_atom_header(p, atom_size, 't', 'f', 'h', 'd');
 	write_be32(p, 0x18);			// flags - default sample duration, default sample size
@@ -211,7 +211,7 @@ ttml_build_mp4(
 	}
 
 	traf_atom_size = ATOM_HEADER_SIZE +
-		ATOM_HEADER_SIZE + sizeof(tfhd_atom_t) +
+		ATOM_HEADER_SIZE + sizeof(ttml_tfhd_atom_t) +
 		sizeof(trun_atom) +
 		sizeof(sdtp_atom);
 


### PR DESCRIPTION
offsets should be relative to moof atom start.
also, renamed tfhd_atom_t in all files it's defined, to avoid collisions