### PR TITLE
read cache optimizations

### DIFF
--- a/vod/filters/audio_filter.c
+++ b/vod/filters/audio_filter.c
@@ -1333,7 +1333,7 @@ audio_filter_process(void* context)
 			rc = source->cur_frame_part.frames_source->start_frame(
 				source->cur_frame_part.frames_source_context, 
 				source->cur_frame,
-				ULLONG_MAX);
+				NULL);
 			if (rc != VOD_OK)
 			{
 				return rc;

--- a/vod/input/frames_source.h
+++ b/vod/input/frames_source.h
@@ -2,14 +2,14 @@
 #define __FRAMES_SOURCE_H__
 
 // includes
-#include "../common.h"
+#include "read_cache.h"
 
 // typedefs
 struct input_frame_s;
 
 typedef struct {
 	void(*set_cache_slot_id)(void* context, int cache_slot_id);
-	vod_status_t(*start_frame)(void* context, struct input_frame_s* frame, uint64_t min_offset);
+	vod_status_t(*start_frame)(void* context, struct input_frame_s* frame, read_cache_hint_t* cache_hint);
 	vod_status_t(*read)(void* context, u_char** buffer, uint32_t* size, bool_t* frame_done);
 	void(*disable_buffer_reuse)(void* context);
 } frames_source_t;

--- a/vod/input/frames_source_cache.c
+++ b/vod/input/frames_source_cache.c
@@ -37,13 +37,13 @@ frames_source_cache_set_cache_slot_id(void* ctx, int cache_slot_id)
 }
 
 static vod_status_t
-frames_source_cache_start_frame(void* ctx, input_frame_t* frame, uint64_t min_offset)
+frames_source_cache_start_frame(void* ctx, input_frame_t* frame, read_cache_hint_t* cache_hint)
 {
 	frames_source_cache_state_t* state = ctx;
 
 	state->req.cur_offset = frame->offset;
 	state->req.end_offset = frame->offset + frame->size;
-	state->req.min_offset = min_offset;
+	state->req.hint = cache_hint;
 
 	return VOD_OK;
 }

--- a/vod/input/frames_source_memory.c
+++ b/vod/input/frames_source_memory.c
@@ -33,7 +33,7 @@ frames_source_memory_set_cache_slot_id(void* ctx, int cache_slot_id)
 }
 
 static vod_status_t
-frames_source_memory_start_frame(void* ctx, input_frame_t* frame, uint64_t min_offset)
+frames_source_memory_start_frame(void* ctx, input_frame_t* frame, read_cache_hint_t* cache_hint)
 {
 	frames_source_memory_state_t* state = ctx;
 

--- a/vod/input/read_cache.c
+++ b/vod/input/read_cache.c
@@ -54,12 +54,14 @@ read_cache_get_from_cache(
 	uint32_t* size)
 {
 	media_clip_source_t* source = request->source;
+	read_cache_hint_t* hint;
 	cache_buffer_t* target_buffer;
 	cache_buffer_t* cur_buffer;
 	uint32_t read_size;
 	uint64_t aligned_last_offset;
 	uint64_t offset = request->cur_offset;
 	size_t alignment;
+	int cache_slot_id;
 
 	// check whether we already have the requested offset
 	for (cur_buffer = state->buffers; cur_buffer < state->buffers_end; cur_buffer++)
@@ -75,31 +77,44 @@ read_cache_get_from_cache(
 
 	// don't have the offset in cache
 	alignment = state->alignment - 1;
-	target_buffer = &state->buffers[request->cache_slot_id % state->buffer_count];
+	cache_slot_id = request->cache_slot_id;
 
 	// start reading from the min offset, if that would contain the whole frame
 	// Note: this condition is intended to optimize the case in which the frame order 
 	//		in the output segment is <video1><audio1> while on disk it's <audio1><video1>. 
 	//		in this case it would be better to start reading from the beginning, even 
 	//		though the first frame that is requested is the second one
-	if (request->min_offset < offset && 
-		request->end_offset < (request->min_offset & ~alignment) + state->buffer_size)
+	hint = request->hint;
+	if (hint != NULL && 
+		hint->min_offset < offset && 
+		hint->min_offset + state->buffer_size / 4 > offset &&
+		request->end_offset < (hint->min_offset & ~alignment) + state->buffer_size)
 	{
-		offset = request->min_offset;
+		offset = hint->min_offset;
+		cache_slot_id = hint->min_offset_slot_id;
 	}
 	offset &= ~alignment;
 
 	// calculate the read size
 	read_size = state->buffer_size;
+	target_buffer = &state->buffers[cache_slot_id % state->buffer_count];
 
 	// don't read anything that is already in the cache
 	for (cur_buffer = state->buffers; cur_buffer < state->buffers_end; cur_buffer++)
 	{
-		if (cur_buffer != target_buffer &&
-			cur_buffer->source == source &&
-			cur_buffer->start_offset > offset)
+		if (cur_buffer == target_buffer ||
+			cur_buffer->source != source)
+		{
+			continue;
+		}
+
+		if (cur_buffer->start_offset > offset)
 		{
 			read_size = vod_min(read_size, cur_buffer->start_offset - offset);
+		}
+		else if (cur_buffer->end_offset > offset)
+		{
+			offset = cur_buffer->end_offset & ~alignment;
 		}
 	}
 

--- a/vod/input/read_cache.h
+++ b/vod/input/read_cache.h
@@ -28,11 +28,16 @@ typedef struct {
 } read_cache_state_t;
 
 typedef struct {
+	uint64_t min_offset;
+	int min_offset_slot_id;
+} read_cache_hint_t;
+
+typedef struct {
 	int cache_slot_id;
 	struct media_clip_source_s* source;
 	uint64_t cur_offset;
 	uint64_t end_offset;
-	uint64_t min_offset;
+	read_cache_hint_t* hint;
 } read_cache_request_t;
 
 typedef struct {

--- a/vod/mkv/mkv_builder.c
+++ b/vod/mkv/mkv_builder.c
@@ -832,7 +832,7 @@ mkv_builder_start_frame(mkv_fragment_writer_state_t* state)
 	rc = state->cur_frame_part.frames_source->start_frame(
 		state->cur_frame_part.frames_source_context,
 		state->cur_frame, 
-		ULLONG_MAX);
+		NULL);
 	if (rc != VOD_OK)
 	{
 		return rc;

--- a/vod/mp4/mp4_builder.c
+++ b/vod/mp4/mp4_builder.c
@@ -240,7 +240,7 @@ mp4_builder_frame_writer_process(fragment_writer_state_t* state)
 			return VOD_OK;
 		}
 
-		rc = state->cur_frame_part.frames_source->start_frame(state->cur_frame_part.frames_source_context, state->cur_frame, ULLONG_MAX);
+		rc = state->cur_frame_part.frames_source->start_frame(state->cur_frame_part.frames_source_context, state->cur_frame, NULL);
 		if (rc != VOD_OK)
 		{
 			return rc;
@@ -346,7 +346,7 @@ mp4_builder_frame_writer_process(fragment_writer_state_t* state)
 			}
 		}
 
-		rc = state->cur_frame_part.frames_source->start_frame(state->cur_frame_part.frames_source_context, state->cur_frame, ULLONG_MAX);
+		rc = state->cur_frame_part.frames_source->start_frame(state->cur_frame_part.frames_source_context, state->cur_frame, NULL);
 		if (rc != VOD_OK)
 		{
 			return rc;

--- a/vod/mp4/mp4_decrypt.c
+++ b/vod/mp4/mp4_decrypt.c
@@ -92,12 +92,12 @@ mp4_decrypt_set_cache_slot_id(void* ctx, int cache_slot_id)
 }
 
 static vod_status_t
-mp4_decrypt_start_frame(void* ctx, input_frame_t* frame, uint64_t min_offset)
+mp4_decrypt_start_frame(void* ctx, input_frame_t* frame, read_cache_hint_t* cache_hint)
 {
 	mp4_decrypt_state_t* state = ctx;
 	vod_status_t rc;
 
-	rc = state->frames_source->start_frame(state->frames_source_context, frame, min_offset);
+	rc = state->frames_source->start_frame(state->frames_source_context, frame, cache_hint);
 	if (rc != VOD_OK)
 	{
 		return rc;

--- a/vod/thumb/thumb_grabber.c
+++ b/vod/thumb/thumb_grabber.c
@@ -564,7 +564,7 @@ thumb_grabber_process(void* context)
 			rc = state->cur_frame_part.frames_source->start_frame(
 				state->cur_frame_part.frames_source_context,
 				state->cur_frame,
-				ULLONG_MAX);
+				NULL);
 			if (rc != VOD_OK)
 			{
 				return rc;


### PR DESCRIPTION
1. do not use min offset if it's too far behind start offset
2. do not read data that is already in cache - trim from both ends
3. when using min offset, use the cache slot of the stream to which min offset belongs