### PR TITLE
audio cenc - must always init the segment writer

### DIFF
--- a/vod/mp4/mp4_cenc_encrypt.c
+++ b/vod/mp4/mp4_cenc_encrypt.c
@@ -954,14 +954,14 @@ mp4_cenc_encrypt_audio_get_fragment_writer(
 		return rc;
 	}
 
+	segment_writer->write_tail = mp4_cenc_encrypt_audio_write_buffer;
+	segment_writer->write_head = NULL;
+	segment_writer->context = state;
+
 	if (!mp4_cenc_encrypt_move_to_next_frame(state, NULL))
 	{
 		return VOD_OK;
 	}
-
-	segment_writer->write_tail = mp4_cenc_encrypt_audio_write_buffer;
-	segment_writer->write_head = NULL;
-	segment_writer->context = state;
 
 	return VOD_OK;
 }


### PR DESCRIPTION
even if there are no frames, since it will be used when building the header.