### PR TITLE
YUM repo restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,17 +127,15 @@ Debug settings:
 #### Debian/Ubuntu deb package
 *Ubuntu NOTE: before trying to install kaltura-nginx, you must also make sure the multiverse repo is enabled*
 
-Install the GPG key:
-```
-# wget -O - http://installrepo.kaltura.org/repo/apt/debian/kaltura-deb.gpg.key|apt-key add -
-```
 For Debian Wheezy [7], Debian Jessie [8], Ubuntu 14.04 and 14.10, add this repo:
 ```
+# wget -O - http://installrepo.kaltura.org/repo/apt/debian/kaltura-deb.gpg.key|apt-key add -
 # echo "deb [arch=amd64] http://installrepo.kaltura.org/repo/apt/debian mercury main" > /etc/apt/sources.list.d/kaltura.list
 ```
 
 For Ubuntu 16.04, 16.10 add this repo:
 ```
+# wget -O - http://installrepo.kaltura.org/repo/apt/xenial/kaltura-deb-256.gpg.key|apt-key add -
 # echo "deb [arch=amd64] http://installrepo.kaltura.org/repo/apt/xenial mercury main" > /etc/apt/sources.list.d/kaltura.list
 ```
 

--- a/README.md
+++ b/README.md
@@ -118,19 +118,10 @@ Debug settings:
 
 ### Installation
 
-#### RHEL/CentOS RPM
-If you are using RHEL or CentOS 6, you can install by setting up the repo:
+#### RHEL/CentOS 6/7 RPM
 ```
 # rpm -ihv http://installrepo.kaltura.org/releases/kaltura-release.noarch.rpm
 # yum install kaltura-nginx
-```
-If you are using RHEL/CentOS7, install the kaltura-release RPM and modify /etc/yum.repos.d/kaltura.repo to read:
-```
-baseurl = http://installrepo.kaltura.org/releases/rhel7/RPMS/$basearch/
-```
-Instead of the default:
-```
-baseurl = http://installrepo.kaltura.org/releases/latest/RPMS/$basearch/
 ```
 
 #### Debian/Ubuntu deb package


### PR DESCRIPTION
We now use the $releasever var so there's no need to edit the
kaltura.repo file when deploying on RHEL/CentOS 7.