### PR TITLE
align clip from offset to kfs only for vod

### DIFF
--- a/vod/media_set_parser.c
+++ b/vod/media_set_parser.c
@@ -1902,8 +1902,11 @@ media_set_apply_clip_from(
 	{
 		clip_offset = clip_from - original_clip_time;
 
+		// Note: aligning to keyframes only in case of vod, since in live, 
+		//	alignment to keyframes will happen in segmenter_get_live_window
 		sequence = &media_set->sequences[0];
-		if (sequence->key_frame_durations != NULL)
+		if (sequence->key_frame_durations != NULL && 
+			media_set->type == MEDIA_SET_VOD)
 		{
 			// align to key frames
 			initial_offset = timing->first_time + sequence->first_key_frame_offset - timing->times[clip_index];


### PR DESCRIPTION
in case of live, it will be aligned in segmenter_get_live_window. aligning it twice can lead to less accurate clipping (clip from -> next kf -> next segment -> next kf)