### PR TITLE
Abort if Nginx version >= 1.13

### DIFF
--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -28,6 +28,10 @@
 #include "vod/manifest_utils.h"
 #include "vod/input/silence_generator.h"
 
+#if (nginx_version >= 1013000)
+    #error "Sorry, the Nginx VOD module does not currently support 1.13 and above. For more info, see https://github.com/kaltura/nginx-vod-module/issues/645.";
+#endif
+
 #if (NGX_HAVE_LIB_AV_CODEC)
 #include "ngx_http_vod_thumb.h"
 #include "ngx_http_vod_volume_map.h"

--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -2,6 +2,10 @@
 #include <ngx_core.h>
 #include <ngx_http.h>
 #include <nginx.h>
+#if (nginx_version >= 1013000)
+    #error "Sorry, the Nginx VOD module does not currently support 1.13 and above. For more info, see https://github.com/kaltura/nginx-vod-module/issues/645.";
+#endif
+
 #include <ngx_event.h>
 #include <ngx_md5.h>
 
@@ -27,10 +31,6 @@
 #include "vod/media_set_parser.h"
 #include "vod/manifest_utils.h"
 #include "vod/input/silence_generator.h"
-
-#if (nginx_version >= 1013000)
-    #error "Sorry, the Nginx VOD module does not currently support 1.13 and above. For more info, see https://github.com/kaltura/nginx-vod-module/issues/645.";
-#endif
 
 #if (NGX_HAVE_LIB_AV_CODEC)
 #include "ngx_http_vod_thumb.h"
@@ -205,7 +205,6 @@ struct ngx_http_vod_ctx_s {
 
 	// segment requests only
 	size_t content_length;
-	size_t size_limit;
 	read_cache_state_t read_cache_state;
 	ngx_http_vod_frame_processor_t frame_processor;
 	void* frame_processor_state;
@@ -2805,9 +2804,12 @@ ngx_http_vod_init_frame_processing(ngx_http_vod_ctx_t *ctx)
 	}
 
 	// initialize the response writer
+	ctx->out.buf = NULL;
+	ctx->out.next = NULL;
 	ctx->write_segment_buffer_context.r = r;
 	ctx->write_segment_buffer_context.chain_head = &ctx->out;
 	ctx->write_segment_buffer_context.chain_end = &ctx->out;
+	ctx->write_segment_buffer_context.total_size = 0;
 
 	ctx->segment_writer.write_tail = ngx_http_vod_write_segment_buffer;
 	ctx->segment_writer.write_head = ngx_http_vod_write_segment_header_buffer;
@@ -2851,17 +2853,6 @@ ngx_http_vod_init_frame_processing(ngx_http_vod_ctx_t *ctx)
 		{
 			return NGX_DONE;
 		}
-
-		// in case of range request, get the end offset
-		if (ctx->submodule_context.r->headers_in.range != NULL &&
-			ngx_http_vod_range_parse(
-				&ctx->submodule_context.r->headers_in.range->value,
-				ctx->content_length,
-				&range_start,
-				&range_end) == NGX_OK)
-		{
-			ctx->size_limit = range_end;
-		}
 	}
 
 	// write the initial buffer if provided
@@ -2879,7 +2870,14 @@ ngx_http_vod_init_frame_processing(ngx_http_vod_ctx_t *ctx)
 		}
 
 		// in case of a range request that is fully contained in the output buffer (e.g. 0-0), we're done
-		if (ctx->size_limit != 0 && output_buffer.len >= ctx->size_limit && r->header_sent)
+		if (ctx->content_length != 0 &&
+			ctx->submodule_context.r->headers_in.range != NULL &&
+			ngx_http_vod_range_parse(
+				&ctx->submodule_context.r->headers_in.range->value,
+				ctx->content_length,
+				&range_start,
+				&range_end) == NGX_OK &&
+			(size_t)range_end <= output_buffer.len)
 		{
 			return NGX_DONE;
 		}
@@ -2925,13 +2923,6 @@ ngx_http_vod_process_media_frames(ngx_http_vod_ctx_t *ctx)
 			ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ctx->submodule_context.request_context.log, 0,
 				"ngx_http_vod_process_media_frames: frame_processor failed %i", rc);
 			return ngx_http_vod_status_to_ngx_error(ctx->submodule_context.r, rc);
-		}
-
-		if (ctx->size_limit != 0 && 
-			ctx->write_segment_buffer_context.total_size >= ctx->size_limit && 
-			ctx->submodule_context.r->header_sent)
-		{
-			return NGX_OK;
 		}
 
 		// get a buffer to read into
@@ -2995,8 +2986,7 @@ ngx_http_vod_finalize_segment_response(ngx_http_vod_ctx_t *ctx)
 	// if we already sent the headers and all the buffers, just signal completion and return
 	if (r->header_sent)
 	{
-		if (ctx->write_segment_buffer_context.total_size != ctx->content_length &&
-			(ctx->size_limit == 0 || ctx->write_segment_buffer_context.total_size < ctx->size_limit))
+		if (ctx->write_segment_buffer_context.total_size != ctx->content_length)
 		{
 			ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
 				"ngx_http_vod_finalize_segment_response: actual content length %uz is different than reported length %uz",


### PR DESCRIPTION
In light of https://github.com/kaltura/nginx-vod-module/issues/645, abort if Nginx version >= 1.13