### PR TITLE
support nginx 1.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,6 @@ Debug settings:
 1. `--with-debug` - enable debug messages (also requires passing `debug` in the `error_log` directive in nginx.conf).
 2. `--with-cc-opt="-O0"` - disable compiler optimizations (for debugging with gdb)
 
-Note: currently, nginx 1.13 or higher is not supported (see https://github.com/kaltura/nginx-vod-module/issues/645), please use version 1.12.
-
 ### Installation
 
 #### RHEL/CentOS 6/7 RPM

--- a/ngx_child_http_request.c
+++ b/ngx_child_http_request.c
@@ -175,7 +175,7 @@ ngx_child_request_wev_handler(ngx_http_request_t *r)
 		rc = NGX_HTTP_BAD_GATEWAY;
 	}
 
-	if (ctx->send_header_result != NGX_OK)
+	if (ctx->send_header_result == NGX_ERROR || ctx->send_header_result > NGX_OK)
 	{
 		rc = ctx->send_header_result;
 	}
@@ -225,7 +225,7 @@ ngx_child_request_finished_handler(
 	ngx_child_request_context_t* ctx;
 
 	ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-		"ngx_child_request_finished_handler: error code %ui", rc);
+		"ngx_child_request_finished_handler: error code %i", rc);
 
 	// make sure we are not called twice for the same request
 	r->post_subrequest = NULL;


### PR DESCRIPTION
following https://forum.nginx.org/read.php?29,274498,274498
- changed the code so that NGX_AGAIN won't be returned from the vod
  handler, NGX_DONE is returned instead and r->main->count is incremented
- while the module returns NGX_DONE, internally NGX_AGAIN is still being
  used as the status code for pending async operation (=async open, async
  aio, http request)
- NGX_AGAIN may return from some nginx functions when nginx has to wait
  for a write event (e.g. ngx_http_send_header / ngx_http_output_filter)
  these return codes are ignored and do not propagate
- ngx_http_finalize_request is no longer being called with NGX_AGAIN,
  except in the case of a dumped HTTP request which completes with this
  status. in such a case it is needed to call ngx_http_finalize_request
  with NGX_AGAIN in order to have nginx set the writer handler