### PR TITLE
add explicit cache entry release

### DIFF
--- a/ngx_buffer_cache.h
+++ b/ngx_buffer_cache.h
@@ -32,7 +32,13 @@ typedef struct {
 ngx_flag_t ngx_buffer_cache_fetch(
 	ngx_buffer_cache_t* cache,
 	u_char* key,
-	ngx_str_t* buffer);
+	ngx_str_t* buffer,
+	uint32_t* token);
+
+void ngx_buffer_cache_release(
+	ngx_buffer_cache_t* cache,
+	u_char* key,
+	uint32_t token);
 
 ngx_flag_t ngx_buffer_cache_store(
 	ngx_buffer_cache_t* cache,

--- a/ngx_buffer_cache_internal.h
+++ b/ngx_buffer_cache_internal.h
@@ -28,6 +28,7 @@ typedef struct {
 	u_char* start_offset;
 	size_t buffer_size;
 	ngx_atomic_t state;
+	ngx_atomic_t ref_count;
 	time_t access_time;
 	time_t write_time;
 	u_char key[BUFFER_CACHE_KEY_SIZE];


### PR DESCRIPTION
usually the cache entries are needed for a very short time (much shorter than ENTRY_LOCK_EXPIRATION) waiting for the cache expiration blocks the cache from rotating and having the most relevant items.