### PR TITLE
support track selection in progressive download

### DIFF
--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -753,6 +753,7 @@ static ngx_http_vod_uri_param_def_t uri_param_defs[] = {
 static ngx_http_vod_uri_param_def_t pd_uri_param_defs[] = {
 	{ offsetof(ngx_http_vod_loc_conf_t, clip_to_param_name), "clip to", ngx_http_vod_parse_uint64_param, offsetof(media_clip_source_t, clip_to) },
 	{ offsetof(ngx_http_vod_loc_conf_t, clip_from_param_name), "clip from", ngx_http_vod_parse_uint64_param, offsetof(media_clip_source_t, clip_from) },
+	{ offsetof(ngx_http_vod_loc_conf_t, tracks_param_name), "tracks", ngx_http_vod_parse_tracks_param, offsetof(media_clip_source_t, tracks_mask) },
 	{ -1, NULL, NULL, 0 }
 };
 


### PR DESCRIPTION
since the media data is returned as a continuous range, the frames of excluded tracks will still be returned, and the resulting bitrate will be the same as the original.