### PR TITLE
replace newlines in libxml2 errors

### DIFF
--- a/vod/subtitle/dfxp_format.c
+++ b/vod/subtitle/dfxp_format.c
@@ -336,6 +336,8 @@ dfxp_xml_sax_error(void *data, const char *msg, ...)
 	xmlParserCtxtPtr ctxt = data;
 	request_context_t* request_context;
 	va_list args;
+	u_char* end;
+	u_char* p;
 	u_char buf[VOD_MAX_ERROR_STR];
 	size_t n;
 
@@ -348,6 +350,16 @@ dfxp_xml_sax_error(void *data, const char *msg, ...)
 	va_end(args);
 
 	while (--n && (buf[n] == CR || buf[n] == LF)) { /* void */ }
+
+	end = buf + n;
+
+	for (p = buf; p < end; p++)
+	{
+		if (*p == CR || *p == LF)
+		{
+			*p = ' ';
+		}
+	}
 
 	vod_log_error(VOD_LOG_ERR, request_context->log, 0,
 		"dfxp_xml_sax_error: libxml2 error: %*s", n + 1, buf);

--- a/vod/subtitle/dfxp_format.c
+++ b/vod/subtitle/dfxp_format.c
@@ -329,6 +329,23 @@ dfxp_get_duration(xmlDoc *doc)
 	return result;
 }
 
+static void
+dfxp_strip_new_lines(u_char* buf, size_t n)
+{
+	u_char* end;
+	u_char* p;
+
+	end = buf + n;
+
+	for (p = buf; p < end; p++)
+	{
+		if (*p == CR || *p == LF)
+		{
+			*p = ' ';
+		}
+	}
+}
+
 // copied from ngx_http_xslt_sax_error
 static void vod_cdecl
 dfxp_xml_sax_error(void *data, const char *msg, ...)
@@ -336,8 +353,6 @@ dfxp_xml_sax_error(void *data, const char *msg, ...)
 	xmlParserCtxtPtr ctxt = data;
 	request_context_t* request_context;
 	va_list args;
-	u_char* end;
-	u_char* p;
 	u_char buf[VOD_MAX_ERROR_STR];
 	size_t n;
 
@@ -351,15 +366,7 @@ dfxp_xml_sax_error(void *data, const char *msg, ...)
 
 	while (--n && (buf[n] == CR || buf[n] == LF)) { /* void */ }
 
-	end = buf + n;
-
-	for (p = buf; p < end; p++)
-	{
-		if (*p == CR || *p == LF)
-		{
-			*p = ' ';
-		}
-	}
+	dfxp_strip_new_lines(buf, n);
 
 	vod_log_error(VOD_LOG_ERR, request_context->log, 0,
 		"dfxp_xml_sax_error: libxml2 error: %*s", n + 1, buf);
@@ -383,6 +390,8 @@ dfxp_xml_schema_error(void *data, const char *msg, ...)
 	va_end(args);
 
 	while (--n && (buf[n] == CR || buf[n] == LF)) { /* void */ }
+
+	dfxp_strip_new_lines(buf, n);
 
 	vod_log_error(VOD_LOG_WARN, request_context->log, 0,
 		"dfxp_xml_schema_error: libxml2 error: %*s", n + 1, buf);


### PR DESCRIPTION
the code already stripped trailing newlines, but sometimes the newlines appear in the middle of the error string, and break the nginx error log format.