### PR TITLE
live -> vod - clipTo bug fix

### DIFF
--- a/vod/media_set_parser.c
+++ b/vod/media_set_parser.c
@@ -2427,7 +2427,8 @@ media_set_parse_json(
 			return rc;
 		}
 
-		last_clip_end = result->timing.first_time + result->timing.total_duration;
+		last_clip_end = result->timing.original_times[result->timing.total_count - 1] +
+			result->timing.durations[result->timing.total_count - 1];
 	}
 
 	// get the key frame durations


### PR DESCRIPTION
when the original playlist type is live, both clipFrom and clipTo use the live timestamps. therefore, need to use original_times to calculate last_clip_end, even when the final playlist type is vod.
for a playlist that was originally vod, the value of last_clip_end will remain exactly as it was.