### PR TITLE
mkv - truncate the element size instead of failing

### DIFF
--- a/vod/mkv/ebml.h
+++ b/vod/mkv/ebml.h
@@ -16,6 +16,9 @@ typedef enum {
 	EBML_BINARY,
 	EBML_MASTER,
 	EBML_CUSTOM,
+
+	EBML_TYPE_MASK = 0x00ffffff,
+	EBML_TRUNCATE = 0x01000000,
 } ebml_type_t;
 
 typedef struct {
@@ -26,7 +29,7 @@ typedef struct {
 
 typedef struct {
 	uint32_t id;
-	ebml_type_t type;
+	uint32_t type;
 	off_t offset;
 	void* child;
 } ebml_spec_t;

--- a/vod/mkv/mkv_format.c
+++ b/vod/mkv/mkv_format.c
@@ -144,23 +144,23 @@ static ebml_spec_t mkv_spec_index[] = {
 // cluster
 static ebml_spec_t mkv_spec_cluster_fields[] = {
 	{ MKV_ID_CLUSTERTIMECODE,		EBML_UINT,		offsetof(mkv_cluster_t, timecode),			NULL },
-	{ MKV_ID_SIMPLEBLOCK,			EBML_CUSTOM,	0,											mkv_parse_frame },
+	{ MKV_ID_SIMPLEBLOCK,			EBML_CUSTOM | EBML_TRUNCATE,	0,							mkv_parse_frame },
 	{ 0, EBML_NONE, 0, NULL }
 };
 
 static ebml_spec_t mkv_spec_cluster[] = {
-	{ MKV_ID_CLUSTER,				EBML_MASTER,	0,											mkv_spec_cluster_fields },
+	{ MKV_ID_CLUSTER,				EBML_MASTER | EBML_TRUNCATE,	0,							mkv_spec_cluster_fields },
 	{ 0, EBML_NONE, 0, NULL }
 };
 
 static ebml_spec_t mkv_spec_bitrate_estimate_cluster_fields[] = {
 	{ MKV_ID_CLUSTERTIMECODE,		EBML_UINT,		offsetof(mkv_cluster_t, timecode),			NULL },
-	{ MKV_ID_SIMPLEBLOCK,			EBML_CUSTOM,	0,											mkv_parse_frame_estimate_bitrate },
+	{ MKV_ID_SIMPLEBLOCK,			EBML_CUSTOM | EBML_TRUNCATE,	0,							mkv_parse_frame_estimate_bitrate },
 	{ 0, EBML_NONE, 0, NULL }
 };
 
 static ebml_spec_t mkv_spec_bitrate_estimate_cluster[] = {
-	{ MKV_ID_CLUSTER,				EBML_MASTER,	0,											mkv_spec_bitrate_estimate_cluster_fields },
+	{ MKV_ID_CLUSTER,				EBML_MASTER | EBML_TRUNCATE,	0,							mkv_spec_bitrate_estimate_cluster_fields },
 	{ 0, EBML_NONE, 0, NULL }
 };
 


### PR DESCRIPTION
some elements (e.g. cluster) may not be read in full when processing a segment.