### PR TITLE
encryption-at-rest thumbnail fix

### DIFF
--- a/vod/input/frames_source.h
+++ b/vod/input/frames_source.h
@@ -12,6 +12,7 @@ typedef struct {
 	vod_status_t(*start_frame)(void* context, struct input_frame_s* frame, read_cache_hint_t* cache_hint);
 	vod_status_t(*read)(void* context, u_char** buffer, uint32_t* size, bool_t* frame_done);
 	void(*disable_buffer_reuse)(void* context);
+	vod_status_t(*skip_frames)(void* context, uint32_t skip_count);
 } frames_source_t;
 
 #endif // __FRAMES_SOURCE_H__

--- a/vod/input/frames_source_cache.c
+++ b/vod/input/frames_source_cache.c
@@ -93,10 +93,17 @@ frames_source_cache_disable_buffer_reuse(void* ctx)
 	read_cache_disable_buffer_reuse(state->read_cache_state);
 }
 
+static vod_status_t
+frames_source_cache_skip_frames(void* ctx, uint32_t skip_count)
+{
+	return VOD_OK;
+}
+
 // globals
 frames_source_t frames_source_cache = {
 	frames_source_cache_set_cache_slot_id,
 	frames_source_cache_start_frame,
 	frames_source_cache_read,
 	frames_source_cache_disable_buffer_reuse,
+	frames_source_cache_skip_frames,
 };

--- a/vod/input/frames_source_memory.c
+++ b/vod/input/frames_source_memory.c
@@ -60,10 +60,17 @@ frames_source_memory_disable_buffer_reuse(void* ctx)
 {
 }
 
+static vod_status_t
+frames_source_memory_skip_frames(void* ctx, uint32_t skip_count)
+{
+	return VOD_OK;
+}
+
 // globals
 frames_source_t frames_source_memory = {
 	frames_source_memory_set_cache_slot_id,
 	frames_source_memory_start_frame,
 	frames_source_memory_read,
 	frames_source_memory_disable_buffer_reuse,
+	frames_source_memory_skip_frames,
 };

--- a/vod/thumb/thumb_grabber.c
+++ b/vod/thumb/thumb_grabber.c
@@ -227,6 +227,7 @@ thumb_grabber_truncate_frames(
 	input_frame_t* last_key_frame = NULL;
 	input_frame_t* cur_frame;
 	input_frame_t* last_frame;
+	vod_status_t rc;
 	uint64_t dts = track->clip_start_time + track->first_frame_time_offset;
 	uint64_t pts;
 	uint64_t cur_diff;
@@ -279,6 +280,14 @@ thumb_grabber_truncate_frames(
 			min_index = index - last_key_frame_index;
 			min_diff = cur_diff;
 			min_part = last_key_frame_part;
+
+			rc = min_part->frames_source->skip_frames(
+				min_part->frames_source_context,
+				last_key_frame - min_part->first_frame);
+			if (rc != VOD_OK)
+			{
+				return rc;
+			}
 
 			// truncate any frames before the key frame of the closest frame
 			min_part->first_frame = last_key_frame;


### PR DESCRIPTION
need to skip the frames in the auxiliary info when truncating frames