### PR TITLE
Add dolby vision support

### DIFF
--- a/vod/codec_config.c
+++ b/vod/codec_config.c
@@ -183,8 +183,6 @@ codec_config_hevc_config_parse(
 		cfg->dovi_config.el_present_flag = bit_read_stream_get_one(&dovi_reader);
 		cfg->dovi_config.bl_present_flag = bit_read_stream_get_one(&dovi_reader);
 		cfg->dovi_config.dv_bl_signal_compatibility_id = bit_read_stream_get(&dovi_reader, 4);
-		vod_log_debug2(VOD_LOG_DEBUG_LEVEL, request_context->log, 0, 
-			"DoVi Profile/Level: %02d.%02d", cfg->dovi_config.dv_profile, cfg->dovi_config.dv_level);
 	}
 
 	if (reader.stream.eof_reached)
@@ -381,7 +379,6 @@ codec_config_get_hevc_codec_name(request_context_t* request_context, media_info_
 
 	if (media_info->format == FORMAT_DVH1)
 	{
-		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0, "!!! It is Dolby Vision");
 		rc = codec_config_hevc_config_parse(request_context, &media_info->extra_data, &media_info->dovi_data, &cfg, NULL);
 		if (rc != VOD_OK)
 		{

--- a/vod/codec_config.c
+++ b/vod/codec_config.c
@@ -124,7 +124,7 @@ vod_status_t
 codec_config_hevc_config_parse(
 	request_context_t* request_context, 
 	vod_str_t* extra_data, 
-	vod_str_t* dovi_data, 
+	vod_str_t* dvcc_data, 
 	hevc_config_t* cfg, 
 	const u_char** end_pos)
 {
@@ -173,8 +173,8 @@ codec_config_hevc_config_parse(
 		cfg->scalability_mask = bit_read_stream_get(&reader, 16);
 	}*/
 
-	if (dovi_data != NULL) {
-		bit_read_stream_init(&dovi_reader, dovi_data->data, dovi_data->len);
+	if (dvcc_data != NULL) {
+		bit_read_stream_init(&dovi_reader, dvcc_data->data, dvcc_data->len);
 		cfg->dovi_config.dv_version_major = bit_read_stream_get(&dovi_reader, 8);
 		cfg->dovi_config.dv_version_minor = bit_read_stream_get(&dovi_reader, 8);
 		cfg->dovi_config.dv_profile = bit_read_stream_get(&dovi_reader, 7);
@@ -379,7 +379,7 @@ codec_config_get_hevc_codec_name(request_context_t* request_context, media_info_
 
 	if (media_info->format == FORMAT_DVH1)
 	{
-		rc = codec_config_hevc_config_parse(request_context, &media_info->extra_data, &media_info->dovi_data, &cfg, NULL);
+		rc = codec_config_hevc_config_parse(request_context, &media_info->extra_data, &media_info->dvcc_data, &cfg, NULL);
 		if (rc != VOD_OK)
 		{
 			return rc;

--- a/vod/codec_config.h
+++ b/vod/codec_config.h
@@ -23,6 +23,21 @@ typedef struct
 	u_char nula_length_size;
 } avcc_config_t;
 
+// from https://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-bitstreams-within-the-iso-base-media-file-format-v2.0.pdf
+// also referenced on https://github.com/gpac/gpac/blob/e1ef9af46ee8542f9a4ada117432377454e71dfa/include/gpac/internal/isomedia_dev.h#L1332
+typedef struct {
+	uint8_t dv_version_major;
+	uint8_t dv_version_minor;
+	uint8_t dv_profile; // 7 bits
+	uint8_t dv_level; // 6 bits
+	bool_t rpu_present_flag;
+	bool_t el_present_flag;
+	bool_t bl_present_flag;
+	uint8_t dv_bl_signal_compatibility_id; // 4 bits
+	// const unsigned int (28) reserved = 0;
+	// const unsigned int (32)[4] reserved = 0;
+} dovi_config_t;
+
 typedef struct
 {
 	uint8_t configurationVersion;
@@ -58,6 +73,9 @@ typedef struct
 	bool_t non_hevc_base_layer;
 	uint8_t num_layers;
 	uint16_t scalability_mask;
+
+	//used in dolby vision config
+	dovi_config_t dovi_config;
 } hevc_config_t;
 
 typedef struct {
@@ -93,6 +111,7 @@ vod_status_t codec_config_mp4a_config_parse(
 vod_status_t codec_config_hevc_config_parse(
 	request_context_t* request_context,
 	vod_str_t* extra_data,
+	vod_str_t* dovi_data,
 	hevc_config_t* cfg,
 	const u_char** end_pos);
 

--- a/vod/hevc_parser.c
+++ b/vod/hevc_parser.c
@@ -1334,7 +1334,7 @@ hevc_parser_parse_extra_data(
 	uint8_t type_count;
 	uint8_t nal_type;
 
-	rc = codec_config_hevc_config_parse(ctx->request_context, extra_data, &cfg, &start_pos);
+	rc = codec_config_hevc_config_parse(ctx->request_context, extra_data, NULL, &cfg, &start_pos);
 	if (rc != VOD_OK)
 	{
 		return rc;

--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -970,6 +970,7 @@ m3u8_builder_write_video_range(u_char* p, uint8_t transfer_characteristics)
 		p = vod_copy(p, M3U8_VIDEO_RANGE_SDR, sizeof(M3U8_VIDEO_RANGE_SDR) - 1);
 		break;
 
+	case 2:
 	case 16:
 	case 18:
 		p = vod_copy(p, M3U8_VIDEO_RANGE_PQ, sizeof(M3U8_VIDEO_RANGE_PQ) - 1);

--- a/vod/media_format.h
+++ b/vod/media_format.h
@@ -173,6 +173,7 @@ typedef struct media_info_s {
 	uint32_t codec_id;
 	vod_str_t codec_name;
 	vod_str_t extra_data;
+	vod_str_t dovi_data;
 	int64_t empty_duration;		// temporary during parsing
 	int64_t start_time;			// temporary during parsing
 	uint64_t codec_delay;

--- a/vod/media_format.h
+++ b/vod/media_format.h
@@ -173,7 +173,7 @@ typedef struct media_info_s {
 	uint32_t codec_id;
 	vod_str_t codec_name;
 	vod_str_t extra_data;
-	vod_str_t dovi_data;
+	vod_str_t dvcc_data;
 	int64_t empty_duration;		// temporary during parsing
 	int64_t start_time;			// temporary during parsing
 	uint64_t codec_delay;

--- a/vod/mp4/mp4_defs.h
+++ b/vod/mp4/mp4_defs.h
@@ -62,10 +62,12 @@
 #define FORMAT_AVC1	   (0x31637661)
 #define FORMAT_h264	   (0x34363268)
 #define FORMAT_H264	   (0x34363248)
+#define FORMAT_DVA1	   (0x31617664)
 
 // h265 4cc tags
 #define FORMAT_HEV1	   (0x31766568)
 #define FORMAT_HVC1	   (0x31637668)
+#define FORMAT_DVH1	   (0x31687664)
 
 // vp9 4cc tags
 #define FORMAT_VP09    (0x39307076)

--- a/vod/mp4/mp4_defs.h
+++ b/vod/mp4/mp4_defs.h
@@ -34,6 +34,7 @@
 #define ATOM_NAME_SINF (0x666e6973)		// protection scheme information
 #define ATOM_NAME_AVCC (0x43637661)		// advanced video codec configuration
 #define ATOM_NAME_HVCC (0x43637668)		// high efficiency video codec configuration
+#define ATOM_NAME_DVCC (0x43637664)		// dolby vision codec configuration
 #define ATOM_NAME_VPCC (0x43637076)		// vp9 codec configuration
 #define ATOM_NAME_ESDS (0x73647365)		// elementary stream description
 #define ATOM_NAME_DAC3 (0x33636164)

--- a/vod/mp4/mp4_parser.c
+++ b/vod/mp4/mp4_parser.c
@@ -1963,8 +1963,8 @@ mp4_parser_parse_video_extra_data_atom(void* ctx, atom_info_t* atom_info)
 	case ATOM_NAME_HVCC:
 		break;
 	case ATOM_NAME_DVCC:
-		context->media_info.dovi_data.len = atom_info->size;
-		context->media_info.dovi_data.data = (u_char*)atom_info->ptr;
+		context->media_info.dvcc_data.len = atom_info->size;
+		context->media_info.dvcc_data.data = (u_char*)atom_info->ptr;
 		return VOD_OK;
 
 	case ATOM_NAME_VPCC:

--- a/vod/mp4/mp4_parser.c
+++ b/vod/mp4/mp4_parser.c
@@ -1953,7 +1953,7 @@ static vod_status_t
 mp4_parser_parse_video_extra_data_atom(void* ctx, atom_info_t* atom_info)
 {
 	metadata_parse_context_t* context = (metadata_parse_context_t*)ctx;
-
+	
 	switch (atom_info->name)
 	{
 	case ATOM_NAME_SINF:
@@ -1973,7 +1973,7 @@ mp4_parser_parse_video_extra_data_atom(void* ctx, atom_info_t* atom_info)
 	default:
 		return VOD_OK;
 	}
-
+	
 	context->media_info.extra_data.len = atom_info->size;
 	context->media_info.extra_data.data = (u_char*)atom_info->ptr;
 	

--- a/vod/mp4/mp4_parser.c
+++ b/vod/mp4/mp4_parser.c
@@ -2632,11 +2632,13 @@ mp4_parser_process_moov_atom_callback(void* ctx, atom_info_t* atom_info)
 		case FORMAT_AVC1:
 		case FORMAT_h264:
 		case FORMAT_H264:
+		case FORMAT_DVA1:
 			metadata_parse_context.media_info.codec_id = VOD_CODEC_ID_AVC;
 			break;
 
 		case FORMAT_HEV1:
 		case FORMAT_HVC1:
+		case FORMAT_DVH1:
 			metadata_parse_context.media_info.codec_id = VOD_CODEC_ID_HEVC;
 			break;
 

--- a/vod/mp4/mp4_parser.c
+++ b/vod/mp4/mp4_parser.c
@@ -1953,7 +1953,7 @@ static vod_status_t
 mp4_parser_parse_video_extra_data_atom(void* ctx, atom_info_t* atom_info)
 {
 	metadata_parse_context_t* context = (metadata_parse_context_t*)ctx;
-	
+
 	switch (atom_info->name)
 	{
 	case ATOM_NAME_SINF:
@@ -1961,13 +1961,19 @@ mp4_parser_parse_video_extra_data_atom(void* ctx, atom_info_t* atom_info)
 
 	case ATOM_NAME_AVCC:
 	case ATOM_NAME_HVCC:
+		break;
+	case ATOM_NAME_DVCC:
+		context->media_info.dovi_data.len = atom_info->size;
+		context->media_info.dovi_data.data = (u_char*)atom_info->ptr;
+		return VOD_OK;
+
 	case ATOM_NAME_VPCC:
 		break;			// handled outside the switch
 
 	default:
 		return VOD_OK;
 	}
-	
+
 	context->media_info.extra_data.len = atom_info->size;
 	context->media_info.extra_data.data = (u_char*)atom_info->ptr;
 	


### PR DESCRIPTION
Hello,

We at @cbsinteractive are working on dynamically segment and serve HDR-10 / Dolby Vision renditions.  I'm opening this PR at this early stage of development to allow us to do an initial pass in the implementation and collect feedback. 

### Questions

1. Instead of using the `extra_data` field in `media_info_t`, I'm storing the dvcC atom data in a different field called `dvcc_data`. Should we transform `extra_data` in an array of `vod_str_t`s and store it in there?

2. Should I remove the comments pointing to the Dolby Vision specification?

### TODO

- [ ] Add the conditional for AVC+DoVi files(FORMAT_DVA1)
- [ ] Check if we're passing the correct `VIDEO_RANGE` on AVC+DoVi files



