### PR TITLE
increase MAX_SLICE_HEADER_SIZE

### DIFF
--- a/vod/mp4/mp4_cbcs_encrypt.c
+++ b/vod/mp4/mp4_cbcs_encrypt.c
@@ -13,7 +13,7 @@
 // constants
 #define MIN_ENCRYPTED_PACKET_SIZE (1 + AES_BLOCK_SIZE)		// minimum 1 byte for slice header
 #define ENCRYPTED_BLOCK_PERIOD (10)							// 1 out of 10 blocks is encrypted
-#define MAX_SLICE_HEADER_SIZE (80)
+#define MAX_SLICE_HEADER_SIZE (128)
 #define ENCRYPT_KEY_SIZE (16)
 
 // typedefs


### PR DESCRIPTION
in some cases 80 is not enough, currently increasing only up to 128.
increasing above 160 requires some refactor (can no longer assume all bytes in the buffer after the first encrypted block are clear)