### PR TITLE
HLS: support AVERAGE-BANDWIDTH attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,9 @@ Optional fields:
 * `bitrate` - an object that can be used to set the bitrate for the different media types,
 	in bits per second. For example, `{"v": 900000, "a": 64000}`. If the bitrate is not supplied,
 	nginx-vod-module will estimate it based on the last clip in the sequence.
+* `avg_bitrate` - an object that can be used to set the average bitrate for the different media types,
+	in bits per second. See `bitrate` above for a sample object. If specified, the module will use
+	the value to populate the AVERAGE-BANDWIDTH attribute of `#EXT-X-STREAM-INF` in HLS.
 
 #### Clip (abstract)
 
@@ -926,7 +929,7 @@ an HLS manifest will contain #EXTINF:10
 frame rate of 29.97 and 10 second segments it will report the first segment as 10.01. accurate mode also
 takes into account the key frame alignment, in case `vod_align_segments_to_key_frames` is on
 
-### vod_media_set_override_json
+#### vod_media_set_override_json
 * **syntax**: `vod_media_set_override_json json`
 * **default**: `{}`
 * **context**: `http`, `server`, `location`

--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -5083,11 +5083,14 @@ ngx_http_vod_map_media_set_apply(ngx_http_vod_ctx_t *ctx, ngx_str_t* mapping, in
 
 			// mapping result is a simple file path, set the uri of the current source
 			ctx->submodule_context.media_set.id = mapped_media_set.id;
+			ctx->submodule_context.media_set.segmenter_conf = mapped_media_set.segmenter_conf;
 			sequence = cur_source->sequence;
 			sequence->mapped_uri = mapped_source->mapped_uri;
 			sequence->language = mapped_media_set.sequences->language;
 			sequence->label = mapped_media_set.sequences->label;
 			sequence->id = mapped_media_set.sequences->id;
+			ngx_memcpy(sequence->bitrate, mapped_media_set.sequences->bitrate, sizeof(sequence->bitrate));
+			ngx_memcpy(sequence->avg_bitrate, mapped_media_set.sequences->avg_bitrate, sizeof(sequence->avg_bitrate));
 			cur_source->mapped_uri = mapped_source->mapped_uri;
 			cur_source->encryption_key = mapped_source->encryption_key;
 

--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -1080,7 +1080,8 @@ ngx_http_vod_parse_uri_path(
 		cur_sequence->first_key_frame_offset = 0;
 		cur_sequence->key_frame_durations = NULL;
 		cur_sequence->drm_info = NULL;
-		vod_memzero(cur_sequence->bitrate, sizeof(cur_sequence->bitrate));
+		ngx_memzero(cur_sequence->bitrate, sizeof(cur_sequence->bitrate));
+		ngx_memzero(cur_sequence->avg_bitrate, sizeof(cur_sequence->avg_bitrate));
 
 		parts[1] = multi_uri.middle_parts[i];
 		rc = ngx_http_vod_merge_string_parts(r, parts, 3, &cur_uri);

--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -36,6 +36,7 @@ static const u_char m3u8_header[] = "#EXTM3U\n";
 static const u_char m3u8_footer[] = "#EXT-X-ENDLIST\n";
 static const char m3u8_stream_inf_video[] = "#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=%uD,RESOLUTION=%uDx%uD,FRAME-RATE=%uD.%03uD,CODECS=\"%V";
 static const char m3u8_stream_inf_audio[] = "#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=%uD,CODECS=\"%V";
+static const char m3u8_average_bandwidth[] = ",AVERAGE-BANDWIDTH=%uD";
 static const char m3u8_iframe_stream_inf[] = "#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=%uD,RESOLUTION=%uDx%uD,CODECS=\"%V\",URI=\"";
 static const u_char m3u8_discontinuity[] = "#EXT-X-DISCONTINUITY\n";
 static const char byte_range_tag_format[] = "#EXT-X-BYTERANGE:%uD@%uD\n";
@@ -994,6 +995,7 @@ m3u8_builder_write_variants(
 	media_info_t* video = NULL;
 	media_info_t* audio = NULL;
 	uint32_t bitrate;
+	uint32_t avg_bitrate;
 	uint32_t muxed_tracks = adaptation_set->type == ADAPTATION_TYPE_MUXED ? MEDIA_TYPE_COUNT : 1;
 
 	vod_memzero(tracks, sizeof(tracks));
@@ -1019,19 +1021,27 @@ m3u8_builder_write_variants(
 		{
 			video = &tracks[MEDIA_TYPE_VIDEO]->media_info;
 			bitrate = video->bitrate;
+			avg_bitrate = video->avg_bitrate;
 			if (group_audio_track != NULL)
 			{
 				audio = &group_audio_track->media_info;
-				bitrate += audio->bitrate;
 			}
 			else if (tracks[MEDIA_TYPE_AUDIO] != NULL)
 			{
 				audio = &tracks[MEDIA_TYPE_AUDIO]->media_info;
-				bitrate += audio->bitrate;
 			}
 			else
 			{
 				audio = NULL;
+			}
+
+			if (audio != NULL)
+			{
+				bitrate += audio->bitrate;
+				if (avg_bitrate != 0)
+				{
+					avg_bitrate += audio->avg_bitrate;
+				}
 			}
 
 			p = vod_sprintf(p, m3u8_stream_inf_video,
@@ -1057,10 +1067,17 @@ m3u8_builder_write_variants(
 			{
 				audio = &tracks[MEDIA_TYPE_AUDIO]->media_info;
 			}
+
+			avg_bitrate = audio->avg_bitrate;
 			p = vod_sprintf(p, m3u8_stream_inf_audio, audio->bitrate, &audio->codec_name);
 		}
 
 		*p++ = '\"';
+
+		if (avg_bitrate != 0)
+		{
+			p = vod_sprintf(p, m3u8_average_bandwidth, avg_bitrate);
+		}
 
 		if (tracks[MEDIA_TYPE_VIDEO] != NULL)
 		{
@@ -1225,6 +1242,7 @@ m3u8_builder_build_master_playlist(
 	max_video_stream_inf =
 		sizeof(m3u8_stream_inf_video) - 1 + 5 * VOD_INT32_LEN + MAX_CODEC_NAME_SIZE +
 		MAX_CODEC_NAME_SIZE + 1 +		// 1 = ,
+		sizeof(m3u8_average_bandwidth) - 1 + VOD_INT32_LEN +
 		sizeof(M3U8_VIDEO_RANGE_SDR) - 1 +
 		sizeof("\"\n\n") - 1;
 

--- a/vod/media_format.h
+++ b/vod/media_format.h
@@ -169,6 +169,7 @@ typedef struct media_info_s {
 	uint64_t duration;
 	uint32_t duration_millis;
 	uint32_t bitrate;
+	uint32_t avg_bitrate;
 	uint32_t min_frame_duration;	// valid only for video		XXXXX move to video_media_info_t
 	uint32_t codec_id;
 	vod_str_t codec_name;

--- a/vod/media_set.h
+++ b/vod/media_set.h
@@ -61,6 +61,7 @@ struct media_sequence_s {
 	vod_str_t label;
 	language_id_t language;
 	uint32_t bitrate[MEDIA_TYPE_COUNT];
+	uint32_t avg_bitrate[MEDIA_TYPE_COUNT];
 	int64_t first_key_frame_offset;
 	vod_array_part_t* key_frame_durations;
 	uint64_t last_key_frame_time;
@@ -87,8 +88,8 @@ struct media_sequence_s {
 typedef struct {
 	uint32_t* durations;				// [total_count] clip durations in millis
 	uint32_t total_count;				// number of clips in the whole set
-	uint64_t* times;					// [total_count] clip timestamps in miilis
-	uint64_t* original_times;			// [total_count] clip timestamps in miilis
+	uint64_t* times;					// [total_count] clip timestamps in millis
+	uint64_t* original_times;			// [total_count] clip timestamps in millis
 	uint64_t segment_base_time;			// the time of segment 0
 	uint64_t total_duration;			// = sum(durations)
 	uint64_t first_time;				// = times[0]

--- a/vod/media_set_parser.c
+++ b/vod/media_set_parser.c
@@ -120,6 +120,7 @@ static json_object_value_def_t media_sequence_params[] = {
 	{ vod_string("language"),		VOD_JSON_STRING,	offsetof(media_sequence_t, language), media_set_parse_language },
 	{ vod_string("label"),			VOD_JSON_STRING,	offsetof(media_sequence_t, label), media_set_parse_null_term_string },
 	{ vod_string("bitrate"),		VOD_JSON_OBJECT,	offsetof(media_sequence_t, bitrate), media_set_parse_bitrate },
+	{ vod_string("avg_bitrate"),	VOD_JSON_OBJECT,	offsetof(media_sequence_t, avg_bitrate), media_set_parse_bitrate },
 	{ vod_null_string, 0, 0, NULL }
 };
 
@@ -1482,7 +1483,7 @@ media_set_init_look_ahead_segments(
 	uint32_t segment_index_limit;
 
 	cur_output = vod_alloc(request_context->pool,
-		sizeof(cur_output[0]) *  MAX_LOOK_AHEAD_SEGMENTS);
+		sizeof(cur_output[0]) * MAX_LOOK_AHEAD_SEGMENTS);
 	if (cur_output == NULL)
 	{
 		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,

--- a/vod/mkv/mkv_format.c
+++ b/vod/mkv/mkv_format.c
@@ -882,6 +882,7 @@ mkv_metadata_parse(
 		cur_track->media_info.frames_timescale = timescale;
 		cur_track->media_info.codec_delay = track.codec_delay;
 		cur_track->media_info.bitrate = sequence->bitrate[media_type];
+		cur_track->media_info.avg_bitrate = sequence->avg_bitrate[media_type];
 
 		// Note: setting the duration of all tracks to the file duration, since there is no efficient
 		//	way to get the duration of a track

--- a/vod/mp4/mp4_parser.c
+++ b/vod/mp4/mp4_parser.c
@@ -2828,6 +2828,9 @@ mp4_parser_process_moov_atom_callback(void* ctx, atom_info_t* atom_info)
 		metadata_parse_context.media_info.bitrate = bitrate;
 	}
 
+	bitrate = sequence->avg_bitrate[metadata_parse_context.media_info.media_type];
+	metadata_parse_context.media_info.avg_bitrate = bitrate;
+
 	result_track->trak_atom_infos = trak_atom_infos;
 	result_track->media_info = metadata_parse_context.media_info;
 	result_track->sinf_atom = metadata_parse_context.sinf_atom;


### PR DESCRIPTION
set via a new json attribute - 'avg_bitrate'.

also:
- support the 'bitrate' json attribute in simple vod
- support the `segmentDuration` json attribute in simple vod