### PR TITLE
Set CLOSED-CAPTIONS attribute to NONE

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,10 @@ Optional fields:
 	Setting this parameter is equivalent to passing /clipTo/ on the URL.
 * `cache` - boolean, if set to false, the mapping response will not be saved to cache (vod_mapping_cache).
 	The default value is true.
+* `closedCaptions` - array of closed captions objects (see below), containing languages and ids
+	of any embedded CEA-608 / CEA-708 captions. If an empty array is provided, the module will output
+	`CLOSED-CAPTIONS=NONE` on each `EXT-X-STREAM-INF` tag. If the list does not appear in the JSON, the 
+	module will not output any `CLOSED-CAPTIONS` fields in the playlist.
 	
 Live fields:
 * `firstClipTime` - integer, mandatory for all live playlists unless `clipTimes` is specified.
@@ -635,6 +639,17 @@ Mandatory fields:
 	the beginning of the concat clip.
 * `id` - a string that identifies the notification, this id can be referenced by `vod_notification_uri`
 	using the variable `$vod_notification_id`
+
+#### Closed Captions
+
+Mandatory fields:
+* `id` - a string that identifies the embedded captions. This will become the `INSTREAM-ID` field and must
+have one of the following values: `CC1`, `CC3`, `CC3`, `CC4`, or `SERVICEn`, where `n` is between 1 and 63.
+* `label` - a friendly string that indicates the language of the closed caption track.
+
+Optional fields:
+* `language` - a 3-letter (ISO-639-2) language code that indicates the language of the closed caption track.
+
 
 ### Security
 

--- a/vod/media_set.h
+++ b/vod/media_set.h
@@ -15,6 +15,7 @@
 
 #define MAX_LOOK_AHEAD_SEGMENTS (2)
 #define MAX_NOTIFICATIONS (1024)
+#define MAX_CLOSED_CAPTIONS (67)
 #define MAX_CLIPS (128)
 #define MAX_CLIPS_PER_REQUEST (16)
 #define MAX_SEQUENCES (32)
@@ -104,6 +105,12 @@ typedef struct media_notification_s {
 } media_notification_t;
 
 typedef struct {
+	vod_str_t id;
+	language_id_t language;
+	vod_str_t label;
+} media_closed_captions_t;
+
+typedef struct {
 	uint64_t start_time;
 	uint32_t duration;
 } media_look_ahead_segment_t;
@@ -145,6 +152,9 @@ typedef struct {
 	vod_str_t uri;
 
 	media_notification_t* notifications_head;
+
+	media_closed_captions_t* closed_captions;
+	media_closed_captions_t* closed_captions_end;
 
 	// initialized while applying filters
 	uint32_t track_count[MEDIA_TYPE_COUNT];	// sum of track count in all sequences per clip

--- a/vod/media_set_parser.c
+++ b/vod/media_set_parser.c
@@ -41,6 +41,7 @@ enum {
 	MEDIA_SET_PARAM_CLIP_FROM,
 	MEDIA_SET_PARAM_CLIP_TO,
 	MEDIA_SET_PARAM_CACHE,
+	MEDIA_SET_PARAM_CLOSED_CAPTIONS,
 
 	MEDIA_SET_PARAM_COUNT
 };
@@ -57,6 +58,14 @@ enum {
 	MEDIA_NOTIFICATION_PARAM_OFFSET,
 
 	MEDIA_NOTIFICATION_PARAM_COUNT
+};
+
+enum {
+	MEDIA_CLOSED_CAPTIONS_PARAM_ID,
+	MEDIA_CLOSED_CAPTIONS_PARAM_LANGUAGE,
+	MEDIA_CLOSED_CAPTIONS_PARAM_LABEL,
+
+	MEDIA_CLOSED_CAPTIONS_PARAM_COUNT
 };
 
 typedef struct {
@@ -137,6 +146,13 @@ static json_object_key_def_t media_notification_params[] = {
 	{ vod_null_string, 0, 0 }
 };
 
+static json_object_key_def_t media_closed_captions_params[] = {
+	{ vod_string("id"),								VOD_JSON_STRING, MEDIA_CLOSED_CAPTIONS_PARAM_ID },
+	{ vod_string("language"),						VOD_JSON_STRING, MEDIA_CLOSED_CAPTIONS_PARAM_LANGUAGE },
+	{ vod_string("label"),							VOD_JSON_STRING, MEDIA_CLOSED_CAPTIONS_PARAM_LABEL },
+	{ vod_null_string, 0, 0 } 
+};
+
 static json_object_key_def_t media_clip_params[] = {
 	{ vod_string("firstKeyFrameOffset"),			VOD_JSON_INT,	MEDIA_CLIP_PARAM_FIRST_KEY_FRAME_OFFSET },
 	{ vod_string("keyFrameDurations"),				VOD_JSON_ARRAY, MEDIA_CLIP_PARAM_KEY_FRAME_DURATIONS },
@@ -166,6 +182,7 @@ static json_object_key_def_t media_set_params[] = {
 	{ vod_string("clipFrom"),						VOD_JSON_INT,	MEDIA_SET_PARAM_CLIP_FROM },
 	{ vod_string("clipTo"),							VOD_JSON_INT,	MEDIA_SET_PARAM_CLIP_TO },
 	{ vod_string("cache"),							VOD_JSON_BOOL,	MEDIA_SET_PARAM_CACHE },
+	{ vod_string("closedCaptions"), 				VOD_JSON_ARRAY, MEDIA_SET_PARAM_CLOSED_CAPTIONS},
 	{ vod_null_string, 0, 0 }
 };
 
@@ -196,6 +213,7 @@ static vod_hash_t media_clip_source_hash;
 static vod_hash_t media_clip_union_hash;
 static vod_hash_t media_sequence_hash;
 static vod_hash_t media_notification_hash;
+static vod_hash_t media_closed_captions_hash;
 static vod_hash_t media_set_hash;
 static vod_hash_t media_clip_hash;
 
@@ -206,6 +224,7 @@ static hash_definition_t hash_definitions[] = {
 	HASH_TABLE(media_clip_union),
 	HASH_TABLE(media_notification),
 	HASH_TABLE(media_clip),
+	HASH_TABLE(media_closed_captions),
 	{ NULL, NULL, 0, NULL }
 };
 
@@ -781,6 +800,106 @@ media_set_sequence_id_exists(request_params_t* request_params, vod_str_t* id)
 	}
 
 	return FALSE;
+}
+
+static vod_status_t
+media_set_parse_closed_captions(
+	request_context_t* request_context,
+	media_set_t* media_set,
+	vod_json_array_t* array)
+{
+	media_closed_captions_t* cur_output;
+	vod_json_value_t* params[MEDIA_CLOSED_CAPTIONS_PARAM_COUNT];
+	vod_array_part_t* part;
+	vod_json_object_t* cur_pos;
+	vod_status_t rc;
+
+	if (array->type != VOD_JSON_OBJECT && array->count > 0)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"media_set_parse_closed_captions: invalid closed caption type %d expected object", array->type);
+		return VOD_BAD_MAPPING;
+	}
+
+	if (array->count > MAX_CLOSED_CAPTIONS)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"media_set_parse_closed_captions: invalid number of elements in the closed captions array %uz", array->count);
+		return VOD_BAD_MAPPING;
+	}
+
+	cur_output = vod_alloc(request_context->pool, sizeof(cur_output[0]) * array->count);
+	if (cur_output == NULL)
+	{
+		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
+			"media_set_parse_closed_captions: vod_alloc failed");
+		return VOD_ALLOC_FAILED;
+	}
+
+	media_set->closed_captions = cur_output;
+
+	part = &array->part;
+	for (cur_pos = part->first; ; cur_pos++)
+	{
+		if ((void*)cur_pos >= part->last)
+		{
+			if (part->next == NULL)
+			{
+				break;
+			}
+
+			part = part->next;
+			cur_pos = part->first;
+		}
+
+		vod_memzero(params, sizeof(params));
+
+		vod_json_get_object_values(cur_pos, &media_closed_captions_hash, params);
+
+		if (params[MEDIA_CLOSED_CAPTIONS_PARAM_ID] == NULL)
+		{
+			vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+				"media_set_parse_closed_captions: missing id in closed captions object");
+			return VOD_BAD_MAPPING;
+		}
+
+		if (params[MEDIA_CLOSED_CAPTIONS_PARAM_LABEL] == NULL)
+		{
+			vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+				"media_set_parse_closed_captions: missing label in closed captions object");
+			return VOD_BAD_MAPPING;
+		}
+
+		if (params[MEDIA_CLOSED_CAPTIONS_PARAM_LANGUAGE] != NULL)
+		{
+			rc = media_set_parse_language(request_context, params[MEDIA_CLOSED_CAPTIONS_PARAM_LANGUAGE], &cur_output->language);
+			if (rc != VOD_OK)
+			{
+				return rc;
+			}
+		} else 
+		{
+			cur_output->language = 0;
+		}
+
+		rc = media_set_parse_null_term_string(&request_context, params[MEDIA_CLOSED_CAPTIONS_PARAM_ID], &cur_output->id);
+		if (rc != VOD_OK)
+		{
+			return rc;
+		}
+
+		rc = media_set_parse_null_term_string(&request_context, params[MEDIA_CLOSED_CAPTIONS_PARAM_LABEL], &cur_output->label);
+		if (rc != VOD_OK)
+		{
+			return rc;
+		}
+		
+		cur_output++;
+	}
+
+	media_set->closed_captions_end = cur_output;
+
+	return VOD_OK;
 }
 
 static vod_status_t
@@ -2305,6 +2424,18 @@ media_set_parse_json(
 	else
 	{
 		result->cache_mapping = TRUE;
+	}
+
+	if (params[MEDIA_SET_PARAM_CLOSED_CAPTIONS] != NULL)
+	{
+		rc = media_set_parse_closed_captions(
+			request_context,
+			result,
+			&params[MEDIA_SET_PARAM_CLOSED_CAPTIONS]->v.arr);
+		if (rc != VOD_OK)
+		{
+			return rc;
+		}
 	}
 
 	if (params[MEDIA_SET_PARAM_DURATIONS] == NULL)


### PR DESCRIPTION
This PR modifies adds a few lines to `m3u8_builder.c` so that if there is no captions file present for a given video, each EXT-X-STREAM-INF in the master playlist file gets the CLOSED-CAPTION attribute set to NONE. This should prevent the appearance of the closed caption button on videos without captions in Safari, which was a bug that I encountered using this module at my company. The fix was explored after reading [this guide from bitmovin](https://bitmovin.com/docs/player/faqs/why-do-i-see-an-additional-cc1-entry-in-the-subtitle-menu-in-safari-ios
) and the [apple developer docs](https://developer.apple.com/library/archive/qa/qa1801/_index.html
).

When testing with our integration, this simple fix prevented the appearance of this CC button in Safari's native player when captions were not present and did not cause other bugs that we have noticed thus far.