### PR TITLE
add vod_hls_mpegts_align_pts flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1658,6 +1658,14 @@ padding is added as needed.
 When enabled, an ID3 TEXT frame will be outputted in each TS segment, containing a JSON with the absolute segment timestamp.
 The timestamp is measured in milliseconds since the epoch (unixtime x 1000), the JSON structure is: `{"timestamp":1459779115000}`
 
+#### vod_hls_mpegts_align_pts
+* **syntax**: `vod_hls_mpegts_align_pts on/off`
+* **default**: `off`
+* **context**: `http`, `server`, `location`
+
+When enabled, the module will shift back the dts timestamps by the pts delay of the initial frame.
+This can help keep the pts timestamps aligned across multiple renditions.
+
 ### Configuration directives - MSS
 
 #### vod_mss_manifest_file_name_prefix

--- a/ngx_http_vod_hls.c
+++ b/ngx_http_vod_hls.c
@@ -914,7 +914,7 @@ static const ngx_http_vod_request_t hls_enc_key_request = {
 
 static const ngx_http_vod_request_t hls_ts_segment_request = {
 	REQUEST_FLAG_SINGLE_TRACK_PER_MEDIA_TYPE,
-	PARSE_FLAG_FRAMES_ALL | PARSE_FLAG_PARSED_EXTRA_DATA,
+	PARSE_FLAG_FRAMES_ALL | PARSE_FLAG_PARSED_EXTRA_DATA | PARSE_FLAG_INITIAL_PTS_DELAY,
 	REQUEST_CLASS_SEGMENT,
 	SUPPORTED_CODECS,
 	HLS_TIMESCALE,
@@ -983,6 +983,7 @@ ngx_http_vod_hls_create_loc_conf(
 	conf->mpegts_muxer_config.interleave_frames = NGX_CONF_UNSET;
 	conf->mpegts_muxer_config.align_frames = NGX_CONF_UNSET;
 	conf->mpegts_muxer_config.output_id3_timestamps = NGX_CONF_UNSET;
+	conf->mpegts_muxer_config.align_pts = NGX_CONF_UNSET;
 	conf->encryption_method = NGX_CONF_UNSET_UINT;
 	conf->m3u8_config.output_iframes_playlist = NGX_CONF_UNSET;
 	conf->m3u8_config.force_unmuxed_segments = NGX_CONF_UNSET;
@@ -1020,6 +1021,7 @@ ngx_http_vod_hls_merge_loc_conf(
 	ngx_conf_merge_value(conf->mpegts_muxer_config.interleave_frames, prev->mpegts_muxer_config.interleave_frames, 0);
 	ngx_conf_merge_value(conf->mpegts_muxer_config.align_frames, prev->mpegts_muxer_config.align_frames, 1);
 	ngx_conf_merge_value(conf->mpegts_muxer_config.output_id3_timestamps, prev->mpegts_muxer_config.output_id3_timestamps, 0);
+	ngx_conf_merge_value(conf->mpegts_muxer_config.align_pts, prev->mpegts_muxer_config.align_pts, 0);
 	
 	ngx_conf_merge_uint_value(conf->encryption_method, prev->encryption_method, HLS_ENC_NONE);
 

--- a/ngx_http_vod_hls_commands.h
+++ b/ngx_http_vod_hls_commands.h
@@ -128,11 +128,18 @@
 	BASE_OFFSET + offsetof(ngx_http_vod_hls_loc_conf_t, mpegts_muxer_config.output_id3_timestamps),
 	NULL },
 
+	{ ngx_string("vod_hls_mpegts_align_pts"),
+	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+	ngx_conf_set_flag_slot,
+	NGX_HTTP_LOC_CONF_OFFSET,
+	BASE_OFFSET + offsetof(ngx_http_vod_hls_loc_conf_t, mpegts_muxer_config.align_pts),
+	NULL },
+
 	{ ngx_string("vod_hls_force_unmuxed_segments"),
 	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
 	ngx_conf_set_flag_slot,
 	NGX_HTTP_LOC_CONF_OFFSET,
 	BASE_OFFSET + offsetof(ngx_http_vod_hls_loc_conf_t, m3u8_config.force_unmuxed_segments),
 	NULL },
-	
+
 #undef BASE_OFFSET

--- a/vod/hls/hls_muxer.h
+++ b/vod/hls/hls_muxer.h
@@ -26,6 +26,7 @@ typedef void(*hls_get_iframe_positions_callback_t)(
 typedef struct {
 	bool_t interleave_frames;
 	bool_t align_frames;
+	bool_t align_pts;
 	bool_t output_id3_timestamps;
 } hls_mpegts_muxer_conf_t;
 
@@ -63,6 +64,7 @@ typedef struct {
 	// fixed
 	hls_muxer_stream_state_t* first_stream;
 	hls_muxer_stream_state_t* last_stream;
+	bool_t align_pts;
 	uint32_t video_duration;
 
 	// child states


### PR DESCRIPTION
fixes an issue of hls.js stall when playing two renditions in which the lower has b-frames and the higher does not. when switching from low to high, there is an overlap in pts values that the player doesn't recover from.