### PR TITLE
Allow for more than 32 tracks per media type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,8 @@ jobs:
           sudo make install
       - name : Test smoke
         run : /sbin/nginx -V
+      - name : Test bitset
+        run : |
+          cd test/bitset
+          NGX_ROOT=/tmp/builddir/nginx VOD_ROOT=../../ bash build.sh
+          ./bitsettest

--- a/README.md
+++ b/README.md
@@ -111,12 +111,15 @@ In this case, the `load_module` directive should be used in nginx.conf in order 
 Optional recommended settings:
 1. `--with-file-aio` - enable asynchronous I/O support, highly recommended, relevant only to local and mapped modes
 2. `--with-threads` (nginx 1.7.11+) - enable asynchronous file open using thread pool (also requires `vod_open_file_thread_pool` in nginx.conf), relevant only to local and mapped modes
-3. `--with-cc-opt="-O3"` - enable additional compiler optimizations (we saw about 8% reduction in the mp4 parse time
+3. `--with-cc-opt="-O3 -mpopcnt"` - enable additional compiler optimizations (we saw about 8% reduction in the mp4 parse time
 	and frame processing time compared to the nginx default `-O`)
 
 Debug settings:
 1. `--with-debug` - enable debug messages (also requires passing `debug` in the `error_log` directive in nginx.conf).
 2. `--with-cc-opt="-O0"` - disable compiler optimizations (for debugging with gdb)
+
+C Macro Configurations:
+1. `--with-cc-opt="-DNGX_VOD_MAX_TRACK_COUNT=256 -mavx2"` - increase the maximum track count (preferably to multiples of 64). It's recommended to enable vector extensions (AVX2) as well.
 
 ### Installation
 

--- a/ngx_http_vod_mss.c
+++ b/ngx_http_vod_mss.c
@@ -309,20 +309,23 @@ ngx_http_vod_mss_parse_uri_file_name(
 			&conf->segmenter,
 			request_params->segment_time + SEGMENT_FROM_TIMESTAMP_MARGIN);
 
-		if (fragment_params.media_type.len == sizeof(MSS_STREAM_TYPE_VIDEO) - 1 && 
+		if (fragment_params.media_type.len == sizeof(MSS_STREAM_TYPE_VIDEO) - 1 &&
 			ngx_memcmp(fragment_params.media_type.data, MSS_STREAM_TYPE_VIDEO, sizeof(MSS_STREAM_TYPE_VIDEO) - 1) == 0)
 		{
-			request_params->tracks_mask[MEDIA_TYPE_VIDEO] = (1 << mss_track_index(fragment_params.bitrate));
+			vod_track_mask_reset_all_bits(request_params->tracks_mask[MEDIA_TYPE_VIDEO]);
+			vod_set_bit(request_params->tracks_mask[MEDIA_TYPE_VIDEO], mss_track_index(fragment_params.bitrate));
 		}
 		else if (fragment_params.media_type.len == sizeof(MSS_STREAM_TYPE_AUDIO) - 1 &&
 			ngx_memcmp(fragment_params.media_type.data, MSS_STREAM_TYPE_AUDIO, sizeof(MSS_STREAM_TYPE_AUDIO) - 1) == 0)
 		{
-			request_params->tracks_mask[MEDIA_TYPE_AUDIO] = (1 << mss_track_index(fragment_params.bitrate));
+			vod_track_mask_reset_all_bits(request_params->tracks_mask[MEDIA_TYPE_AUDIO]);
+			vod_set_bit(request_params->tracks_mask[MEDIA_TYPE_AUDIO], mss_track_index(fragment_params.bitrate));
 		}
 		else if (fragment_params.media_type.len == sizeof(MSS_STREAM_TYPE_TEXT) - 1 &&
 			ngx_memcmp(fragment_params.media_type.data, MSS_STREAM_TYPE_TEXT, sizeof(MSS_STREAM_TYPE_TEXT) - 1) == 0)
 		{
-			request_params->tracks_mask[MEDIA_TYPE_SUBTITLE] = 1;
+			vod_track_mask_reset_all_bits(request_params->tracks_mask[MEDIA_TYPE_SUBTITLE]);
+			vod_set_bit(request_params->tracks_mask[MEDIA_TYPE_SUBTITLE], 0);
 			*request = &mss_ttml_request;
 			return NGX_OK;
 		}

--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -1042,7 +1042,7 @@ ngx_http_vod_parse_uri_path(
 
 	parts_mask = (1 << multi_uri.parts_count) - 1;
 	
-	uri_count = vod_get_number_of_set_bits(sequences_mask & parts_mask);
+	uri_count = vod_get_number_of_set_bits32(sequences_mask & parts_mask);
 	if (uri_count == 0)
 	{
 		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,

--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -137,7 +137,11 @@ ngx_http_vod_extract_uint32_token_reverse(u_char* start_pos, u_char* end_pos, ui
 }
 
 static u_char*
-ngx_http_vod_extract_track_tokens(u_char* start_pos, u_char* end_pos, uint32_t* result)
+ngx_http_vod_extract_track_tokens(
+	ngx_http_request_t* r,
+	u_char* start_pos,
+	u_char* end_pos,
+	track_mask_t* result)
 {
 	uint32_t stream_index;
 	int media_type;
@@ -162,37 +166,26 @@ ngx_http_vod_extract_track_tokens(u_char* start_pos, u_char* end_pos, uint32_t* 
 
 		start_pos++;		// skip the v/a
 
-		if (start_pos >= end_pos)
+		stream_index = 0;
+		for (; start_pos < end_pos && *start_pos >= '0' && *start_pos <= '9'; start_pos++)
 		{
-			// no index => all streams of the media type
-			result[media_type] = 0xffffffff;
-			break;
-		}
-
-		if (*start_pos >= '0' && *start_pos <= '9')
-		{
-			stream_index = *start_pos - '0';
-			start_pos++;
-
-			if (start_pos < end_pos && *start_pos >= '0' && *start_pos <= '9')
-			{
-				stream_index = stream_index * 10 + *start_pos - '0';
-				start_pos++;
-			}
-		}
-		else
-		{
-			stream_index = 0;
+			stream_index = stream_index * 10 + *start_pos - '0';
 		}
 
 		if (stream_index == 0)
 		{
 			// no index => all streams of the media type
-			result[media_type] = 0xffffffff;
+			vod_track_mask_set_all_bits(result[media_type]);
+		}
+		else if (stream_index > MAX_TRACK_COUNT)
+		{
+			vod_log_error(NGX_LOG_WARN, r->connection->log, 0,
+				"ngx_http_vod_extract_track_tokens: the track index %uD of type %d exceeds the maximum track count of %i",
+				stream_index, media_type, (ngx_int_t)MAX_TRACK_COUNT);
 		}
 		else
 		{
-			result[media_type] |= (1 << (stream_index - 1));
+			vod_set_bit(result[media_type], stream_index - 1);
 		}
 
 		if (start_pos >= end_pos)
@@ -225,8 +218,8 @@ ngx_http_vod_parse_uri_file_name(
 	sequence_tracks_mask_t* sequence_tracks_mask;
 	ngx_str_t* cur_sequence_id;
 	ngx_str_t* last_sequence_id;
-	uint32_t default_tracks_mask;
-	uint32_t* tracks_mask;
+	track_mask_t default_tracks_mask;
+	track_mask_t* tracks_mask;
 	uint32_t segment_index_shift;
 	uint32_t sequence_index;
 	uint32_t clip_index;
@@ -236,10 +229,18 @@ ngx_http_vod_parse_uri_file_name(
 	bool_t tracks_mask_updated;
 	language_id_t lang_id;
 
-	default_tracks_mask = (flags & PARSE_FILE_NAME_MULTI_STREAMS_PER_TYPE) ? 0xffffffff : 1;
+	if (flags & PARSE_FILE_NAME_MULTI_STREAMS_PER_TYPE)
+	{
+		vod_track_mask_set_all_bits(default_tracks_mask);
+	}
+	else
+	{
+		vod_track_mask_reset_all_bits(default_tracks_mask);
+		vod_set_bit(default_tracks_mask, 0);
+	}
 	for (media_type = 0; media_type < MEDIA_TYPE_COUNT; media_type++)
 	{
-		result->tracks_mask[media_type] = default_tracks_mask;
+		vod_memcpy(result->tracks_mask[media_type], default_tracks_mask, sizeof(result->tracks_mask[media_type]));
 	}
 	result->sequences_mask = 0xffffffff;
 	result->clip_index = INVALID_CLIP_INDEX;
@@ -397,6 +398,7 @@ ngx_http_vod_parse_uri_file_name(
 				}
 
 				start_pos = ngx_http_vod_extract_track_tokens(
+					r,
 					start_pos, 
 					end_pos, 
 					tracks_mask);
@@ -442,7 +444,7 @@ ngx_http_vod_parse_uri_file_name(
 				// restore the global mask to the default
 				for (media_type = 0; media_type < MEDIA_TYPE_COUNT; media_type++)
 				{
-					result->tracks_mask[media_type] = default_tracks_mask;
+					vod_memcpy(result->tracks_mask[media_type], default_tracks_mask, sizeof(result->tracks_mask[media_type]));
 				}
 			}
 		}
@@ -450,7 +452,7 @@ ngx_http_vod_parse_uri_file_name(
 	else if (*start_pos == 'v' || *start_pos == 'a')
 	{
 		// tracks
-		start_pos = ngx_http_vod_extract_track_tokens(start_pos, end_pos, result->tracks_mask);
+		start_pos = ngx_http_vod_extract_track_tokens(r, start_pos, end_pos, result->tracks_mask);
 		if (start_pos == NULL)
 		{
 			return NGX_OK;
@@ -647,7 +649,7 @@ ngx_http_vod_parse_uint64_param(ngx_str_t* value, void* output, int offset)
 static ngx_int_t
 ngx_http_vod_parse_tracks_param(ngx_str_t* value, void* output, int offset)
 {
-	uint32_t* tracks_mask = (uint32_t*)((u_char*)output + offset);
+	track_mask_t* tracks_mask = (track_mask_t*)((u_char*)output + offset);
 	u_char* end_pos;
 
 	ngx_memzero(tracks_mask, sizeof(tracks_mask[0]) * MEDIA_TYPE_COUNT);
@@ -1007,6 +1009,7 @@ ngx_http_vod_parse_uri_path(
 	ngx_str_t parts[3];
 	ngx_str_t cur_uri;
 	ngx_int_t rc;
+	track_mask_t track_mask_temp;
 	uint32_t sequences_mask;
 	uint32_t parts_mask;
 	uint32_t media_type;
@@ -1104,7 +1107,8 @@ ngx_http_vod_parse_uri_path(
 		has_tracks = FALSE;
 		for (media_type = 0; media_type < MEDIA_TYPE_COUNT; media_type++)
 		{
-			if ((cur_source->tracks_mask[media_type] & request_params->tracks_mask[media_type]) != 0)
+			vod_track_mask_and_bits(track_mask_temp, cur_source->tracks_mask[media_type], request_params->tracks_mask[media_type]);
+			if (vod_track_mask_is_any_bit_set(track_mask_temp))
 			{
 				has_tracks = TRUE;
 				break;

--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -478,15 +478,13 @@ ngx_http_vod_parse_uri_file_name(
 	// languages
 	if (*start_pos == 'l')
 	{
-		result->langs_mask = ngx_pnalloc(r->pool, LANG_MASK_SIZE);
+		result->langs_mask = ngx_pcalloc(r->pool, LANG_MASK_SIZE * sizeof(result->langs_mask[0]));
 		if (result->langs_mask == NULL)
 		{
 			ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-				"ngx_http_vod_parse_uri_file_name: ngx_pnalloc failed");
+				"ngx_http_vod_parse_uri_file_name: ngx_palloc failed");
 			return ngx_http_vod_status_to_ngx_error(r, VOD_ALLOC_FAILED);
 		}
-
-		ngx_memzero(result->langs_mask, LANG_MASK_SIZE);
 
 		for (;;)
 		{

--- a/ngx_http_vod_thumb.c
+++ b/ngx_http_vod_thumb.c
@@ -312,8 +312,8 @@ ngx_http_vod_thumb_parse_uri_file_name(
 	
 	request_params->segment_time = time;
 	request_params->segment_time_type = time_type;
-	request_params->tracks_mask[MEDIA_TYPE_AUDIO] = 0;
-	request_params->tracks_mask[MEDIA_TYPE_SUBTITLE] = 0;
+	vod_track_mask_reset_all_bits(request_params->tracks_mask[MEDIA_TYPE_AUDIO]);
+	vod_track_mask_reset_all_bits(request_params->tracks_mask[MEDIA_TYPE_SUBTITLE]);
 
 	return NGX_OK;
 }

--- a/ngx_http_vod_volume_map.c
+++ b/ngx_http_vod_volume_map.c
@@ -113,8 +113,8 @@ ngx_http_vod_volume_map_parse_uri_file_name(
 		return rc;
 	}
 
-	request_params->tracks_mask[MEDIA_TYPE_VIDEO] = 0;
-	request_params->tracks_mask[MEDIA_TYPE_SUBTITLE] = 0;
+	vod_track_mask_reset_all_bits(request_params->tracks_mask[MEDIA_TYPE_VIDEO]);
+	vod_track_mask_reset_all_bits(request_params->tracks_mask[MEDIA_TYPE_SUBTITLE]);
 
 	return NGX_OK;
 }

--- a/test/README.md
+++ b/test/README.md
@@ -1,7 +1,7 @@
 ## nginx-vod-module tests
 
 the accompanied python scripts test the nginx-vod-module, each test script has an associated template file
-that contains environment specific parameters. the template file should be copied and edited to match the 
+that contains environment specific parameters. the template file should be copied and edited to match the
 specific environment on which the tests are run.
 the tests assume that nginx is running with the accompanied nginx.conf file.
 
@@ -24,7 +24,7 @@ sanity + coverage tests, e.g.:
   3. file not found
 
 in order to run the tests nginx should be compiled with the --with-debug switch
-  
+
 ### hls_compare.py
 
 compares the nginx-vod hls implementation to some reference implementation
@@ -59,3 +59,9 @@ this folder contains a stress test for the buffer cache module. in order to exec
 this folder contains tests for the json parser module. in order to execute the test, run:
  * NGX_ROOT=/path/to/nginx/sources VOD_ROOT=/path/to/nginx/vod bash build.sh
  * ./jsontest
+
+### bitset
+
+this folder contains tests for the light bitset implementation. in order to execute the test, run:
+ * NGX_ROOT=/path/to/nginx/sources VOD_ROOT=/path/to/nginx/vod bash build.sh
+ * ./bitsettest

--- a/test/bitset/build.sh
+++ b/test/bitset/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ -z "$NGX_ROOT" ]; then
+	echo "NGX_ROOT not set"
+	exit 1
+fi
+
+if [ -z "$VOD_ROOT" ]; then
+	echo "VOD_ROOT not set"
+	exit 1
+fi
+
+if [ -z "$CC" ]; then
+	CC=cc
+fi
+
+$CC -Wall -g -obitsettest -DNGX_HAVE_LIB_AV_CODEC=0 $VOD_ROOT/vod/common.c $VOD_ROOT/test/bitset/main.c -I $NGX_ROOT/src/core -I $NGX_ROOT/src/event -I $NGX_ROOT/src/event/modules -I $NGX_ROOT/src/os/unix -I $NGX_ROOT/objs -I $VOD_ROOT

--- a/test/bitset/main.c
+++ b/test/bitset/main.c
@@ -1,0 +1,136 @@
+#include <inttypes.h>
+#include <stdio.h>
+#include <ngx_core.h>
+#include <vod/common.h>
+
+#if (NGX_HAVE_VARIADIC_MACROS)
+
+void
+ngx_log_error_core(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
+    const char *fmt, ...)
+
+#else
+
+void
+ngx_log_error_core(ngx_uint_t level, ngx_log_t *log, ngx_err_t err,
+    const char *fmt, va_list args)
+
+#endif
+{
+}
+
+#define assert(cond) if (!(cond)) { printf("Error: assertion failed, file=%s line=%d\n", __FILE__, __LINE__); success = FALSE; }
+
+#define BITS (128)
+bool_t test_bitset()
+{
+	bool_t success = TRUE;
+	uint64_t mask[vod_array_length_for_bits(BITS)]; // [2]
+	uint64_t mask2[vod_array_length_for_bits(BITS)];
+
+	assert(sizeof(mask) == sizeof(uint64_t) * 2);
+
+	assert(vod_array_length_for_bits(63) == 1);
+	assert(vod_array_length_for_bits(64) == 1);
+	assert(vod_array_length_for_bits(65) == 2);
+
+	vod_reset_all_bits(mask, BITS);
+
+	assert(mask[0] == 0);
+	assert(mask[1] == 0);
+	for (int i = 0; i < BITS; i++)
+	{
+		assert(vod_is_bit_set(mask, i) == FALSE);
+	}
+	assert(vod_get_number_of_set_bits_in_mask(mask, BITS) == 0);
+	assert(vod_are_all_bits_set(mask, BITS) == FALSE);
+	assert(vod_is_any_bit_set(mask, BITS) == FALSE);
+
+	vod_set_bit(mask, 0);
+	assert(mask[0] == 1);
+	assert(mask[1] == 0);
+	assert(vod_get_number_of_set_bits_in_mask(mask, BITS) == 1);
+	assert(vod_is_bit_set(mask, 0) == TRUE);
+	assert(vod_is_any_bit_set(mask, 64) == TRUE);
+	assert(vod_is_any_bit_set(mask, BITS) == TRUE);
+	assert(vod_get_lowest_bit_set(mask, BITS) == 0);
+
+	vod_set_bit(mask, 64);
+	assert(mask[0] == 1);
+	assert(mask[1] == 1);
+	assert(vod_get_number_of_set_bits_in_mask(mask, BITS) == 2);
+	assert(vod_get_lowest_bit_set(mask, BITS) == 0);
+
+	vod_reset_bit(mask, 0);
+	vod_reset_bit(mask, 64);
+	assert(!vod_is_bit_set(mask, 0));
+	assert(mask[0] == 0);
+	assert(mask[1] == 0);
+
+	vod_set_all_bits(mask, BITS / 2);
+	assert(mask[0] == 0xffffffffffffffff);
+	assert(mask[1] == 0);
+	assert(vod_are_all_bits_set(mask, 64) == TRUE);
+	assert(vod_are_all_bits_set(mask, BITS) == FALSE);
+	vod_set_bit(mask, 64);
+	vod_set_bit(mask, 65);
+	assert(mask[0] == 0xffffffffffffffff);
+	assert(mask[1] == 0b11);
+	assert(vod_are_all_bits_set(mask, 66) == TRUE);
+
+	vod_reset_bit(mask, 0);
+	vod_reset_bit(mask, 1);
+	assert(vod_get_number_of_set_bits_in_mask(mask, BITS) == 64);
+	assert(vod_get_lowest_bit_set(mask, BITS) == 2);
+
+	vod_reset_all_bits(mask, BITS);
+	vod_set_bit(mask, 64);
+	vod_set_bit(mask, 65);
+	assert(vod_get_lowest_bit_set(mask, BITS) == 64);
+	vod_reset_bit(mask, 64);
+	assert(vod_get_lowest_bit_set(mask, BITS) == 65);
+
+	vod_reset_all_bits(mask, BITS);
+
+	vod_memset(mask, 0xff, sizeof(uint64_t) + 1);
+	assert(mask[0] == 0xffffffffffffffff);
+	assert(*((uint8_t*)&mask[1]) == 0xff);
+	assert(vod_get_number_of_set_bits_in_mask(mask, BITS) == 64 + 8);
+
+	vod_reset_all_bits(mask, BITS);
+	vod_reset_all_bits(mask2, BITS);
+
+	vod_and_bits(mask, mask, mask2, BITS);
+	assert(vod_is_any_bit_set(mask, BITS) == FALSE);
+
+	vod_set_bit(mask, 31);
+	vod_and_bits(mask, mask, mask2, BITS);
+	assert(vod_is_any_bit_set(mask, BITS) == FALSE);
+
+	vod_set_bit(mask, 31);
+	vod_set_bit(mask2, 31);
+	vod_and_bits(mask, mask, mask2, BITS);
+	assert(vod_is_any_bit_set(mask, BITS) == TRUE);
+	assert(vod_is_bit_set(mask, 31) == TRUE);
+
+	vod_memset(mask, 0x55, sizeof(mask));
+	vod_memset(mask2, 0xff, sizeof(mask2));
+	vod_and_bits(mask, mask, mask2, BITS);
+	assert(mask[0] = 0x5555555555555555);
+	assert(mask[1] = 0x5555555555555555);
+	assert(vod_get_number_of_set_bits_in_mask(mask, BITS) == BITS / 2);
+
+	return success;
+}
+
+int main()
+{
+	if (!test_bitset())
+	{
+		printf("One or more tests failed.\n");
+		return 1;
+	}
+
+	printf("All tests passed.\n");
+	return 0;
+}

--- a/test/bitset/main.c
+++ b/test/bitset/main.c
@@ -94,7 +94,7 @@ bool_t test_bitset()
 
 	vod_memset(mask, 0xff, sizeof(uint64_t) + 1);
 	assert(mask[0] == 0xffffffffffffffff);
-	assert(*((uint8_t*)&mask[1]) == 0xff);
+	assert((mask[1] == 0xff00000000000000) != (mask[1] == 0xff));
 	assert(vod_get_number_of_set_bits_in_mask(mask, BITS) == 64 + 8);
 
 	vod_reset_all_bits(mask, BITS);

--- a/test/generate_many_tracks.py
+++ b/test/generate_many_tracks.py
@@ -1,0 +1,53 @@
+import re
+import subprocess
+import sys
+
+# This generates a test file with a large number of audio tracks
+# Used to test builds with a custom NGX_VOD_MAX_TRACK_COUNT value
+# Requires ffmpeg with flite support (check with `ffplay -f lavfi flite=text="test"`)
+
+def parse_langs():
+	blacklist = ['UND', 'ZXX']
+	dict = {}
+	with open('../vod/languages_x.h') as f:
+		for l in f:
+			if l.startswith("LANG("):
+				lang = [x.strip() for x in l[5:-2].split(",")]
+				if lang[0] in blacklist:
+					continue
+
+				identifier = lang[3][1:-1]
+				name_english = lang[4][1:-1].replace('"', '')
+				dict[identifier] = name_english
+	return dict
+
+def generate_ffmpeg_command(languages, max_tracks, output_filename):
+	pattern = re.compile('[\W_]+')
+	c = ['ffmpeg']
+	langs = []
+	for ident in languages.keys():
+		c.extend(['-f', 'lavfi', '-i', 'flite=text="{}",aloop=20:size=3*8000'.format(pattern.sub('', languages[ident]))])
+		langs.append(ident)
+		if len(langs) == max_tracks:
+			break
+
+	c.append('-shortest')
+
+	for i in range(len(langs)):
+		c.extend(['-map', '{}:a'.format(i), '-metadata:s:a:{}'.format(i), 'language={}'.format(langs[i])])
+	c.append(output_filename)
+	return c
+
+if __name__ == '__main__':
+	args = sys.argv[1:]
+	if len(args) > 0:
+		tracks = int(args[0])
+	else:
+		tracks = 128
+
+	languages = parse_langs()
+	command = generate_ffmpeg_command(languages, tracks, "many_tracks.mp4")
+	print('command:')
+	print(*command)
+	print()
+	subprocess.run(command)

--- a/vod/common.c
+++ b/vod/common.c
@@ -12,14 +12,23 @@ vod_get_int_print_len(uint64_t n)
 	return res;
 }
 
+#ifdef VOD_IMPLEMENT_BIT_COUNT
 uint32_t
-vod_get_number_of_set_bits(uint32_t i)
+vod_get_number_of_set_bits32(uint32_t i)
 {
 	// variable-precision SWAR algorithm
 	i = i - ((i >> 1) & 0x55555555);
 	i = (i & 0x33333333) + ((i >> 2) & 0x33333333);
 	return (((i + (i >> 4)) & 0x0F0F0F0F) * 0x01010101) >> 24;
 }
+
+uint32_t
+vod_get_number_of_set_bits64(uint64_t i)
+{
+	return vod_get_number_of_set_bits32((uint32_t)(i & NGX_MAX_UINT32_VALUE)) +
+		vod_get_number_of_set_bits32((uint32_t)(i >> 32));
+}
+#endif
 
 u_char*
 vod_append_hex_string(u_char* p, const u_char* buffer, uint32_t buffer_size)

--- a/vod/common.c
+++ b/vod/common.c
@@ -28,6 +28,21 @@ vod_get_number_of_set_bits64(uint64_t i)
 	return vod_get_number_of_set_bits32((uint32_t)(i & NGX_MAX_UINT32_VALUE)) +
 		vod_get_number_of_set_bits32((uint32_t)(i >> 32));
 }
+
+uint32_t
+vod_get_trailing_zeroes64(uint64_t i)
+{
+	size_t k;
+
+	for (k = 0; k < sizeof(i) * 8; k++)
+	{
+		if ((i >> k) & 1)
+		{
+			return k;
+		}
+	}
+	return -1; /* undefined */
+}
 #endif
 
 u_char*

--- a/vod/common.h
+++ b/vod/common.h
@@ -356,7 +356,17 @@ enum {
 // functions
 int vod_get_int_print_len(uint64_t n);
 
-uint32_t vod_get_number_of_set_bits(uint32_t i);
+#if defined(__GNUC__) || defined(__clang__)
+// On x86 this still uses the slow SWAR algorithm unless "-mpopcnt"
+// is set or any other flag that implies it like "-mavx2"
+#define vod_get_number_of_set_bits32(i) __builtin_popcount(i)
+#define vod_get_number_of_set_bits64(i) __builtin_popcountll(i)
+#else
+#define VOD_IMPLEMENT_BIT_COUNT
+uint32_t vod_get_number_of_set_bits32(uint32_t i);
+uint32_t vod_get_number_of_set_bits64(uint64_t i);
+#endif
+#define vod_get_number_of_set_bits(i) ((sizeof(size_t) <= 4) ? vod_get_number_of_set_bits32(i) : vod_get_number_of_set_bits64(i))
 
 u_char* vod_append_hex_string(u_char* p, const u_char* buffer, uint32_t buffer_size);
 

--- a/vod/common.h
+++ b/vod/common.h
@@ -373,7 +373,6 @@ uint32_t vod_get_number_of_set_bits32(uint32_t i);
 uint32_t vod_get_number_of_set_bits64(uint64_t i);
 uint32_t vod_get_trailing_zeroes64(uint64_t i);
 #endif
-#define vod_get_number_of_set_bits(i) ((sizeof(size_t) <= 4) ? vod_get_number_of_set_bits32(i) : vod_get_number_of_set_bits64(i))
 
 // bit sets
 // always assumes max_bits = n * 64.

--- a/vod/common.h
+++ b/vod/common.h
@@ -16,13 +16,18 @@
 #define vod_div_ceil(x, y) (((x) + (y) - 1) / (y))
 #define vod_array_entries(x) (sizeof(x) / sizeof(x[0]))
 
-#define vod_is_bit_set(mask, index) (((mask)[(index) >> 3] >> ((index) & 7)) & 1)
-#define vod_set_bit(mask, index) (mask)[(index) >> 3] |= 1 << ((index) & 7)
+// bit sets
+#define vod_array_length_for_bits(i) (((i) + 63) >> 6)
+#define vod_is_bit_set(mask, index) (((mask)[(index) / 64] >> ((index) % 64)) & 1)
+#define vod_set_bit(mask, index) ((mask)[(index) / 64] |= ((uint64_t)1 << ((index) % 64)))
+#define vod_reset_bit(mask, index) ((mask)[(index) / 64] &= ~((uint64_t)1 << ((index) % 64)))
+#define vod_set_all_bits(mask, max_bits) vod_memset((mask), 0xff, sizeof(uint64_t) * vod_array_length_for_bits(max_bits));
+#define vod_reset_all_bits(mask, max_bits) vod_memzero((mask), sizeof(uint64_t) * vod_array_length_for_bits(max_bits));
 
 #define vod_no_flag_set(mask, f) (((mask) & (f)) == 0)
 #define vod_all_flags_set(mask, f) (((mask) & (f)) == (f))
 
-// Note: comparing the pointers since in the case of labels if both were derived by the language, 
+// Note: comparing the pointers since in the case of labels if both were derived by the language,
 //		they will have the same pointer and we can skip the memcmp
 #define vod_str_equals(l1, l2) \
 	((l1).len == (l2).len && ((l1).data == (l2).data || vod_memcmp((l1).data, (l2).data, (l1).len) == 0))
@@ -229,15 +234,15 @@ void vod_log_error(vod_uint_t level, vod_log_t *log, int err,
 
 #define VOD_MAX_ERROR_STR NGX_MAX_ERROR_STR
 
-#define VOD_LOG_STDERR            NGX_LOG_STDERR 
-#define VOD_LOG_EMERG             NGX_LOG_EMERG  
-#define VOD_LOG_ALERT             NGX_LOG_ALERT  
-#define VOD_LOG_CRIT              NGX_LOG_CRIT   
-#define VOD_LOG_ERR               NGX_LOG_ERR    
-#define VOD_LOG_WARN              NGX_LOG_WARN   
-#define VOD_LOG_NOTICE            NGX_LOG_NOTICE 
-#define VOD_LOG_INFO              NGX_LOG_INFO   
-#define VOD_LOG_DEBUG             NGX_LOG_DEBUG  
+#define VOD_LOG_STDERR            NGX_LOG_STDERR
+#define VOD_LOG_EMERG             NGX_LOG_EMERG
+#define VOD_LOG_ALERT             NGX_LOG_ALERT
+#define VOD_LOG_CRIT              NGX_LOG_CRIT
+#define VOD_LOG_ERR               NGX_LOG_ERR
+#define VOD_LOG_WARN              NGX_LOG_WARN
+#define VOD_LOG_NOTICE            NGX_LOG_NOTICE
+#define VOD_LOG_INFO              NGX_LOG_INFO
+#define VOD_LOG_DEBUG             NGX_LOG_DEBUG
 
 #define vod_log_error ngx_log_error
 
@@ -273,16 +278,16 @@ typedef ngx_err_t vod_err_t;
 #define vod_log_buffer(level, log, err, prefix, buffer, size)	\
 	if ((log)->log_level & level)								\
 		log_buffer(level, log, err, prefix, buffer, size)
-		
+
 #define MAX_DUMP_BUFFER_SIZE (100)
 
-static vod_inline void 
+static vod_inline void
 log_buffer(unsigned level, vod_log_t* log, int err, const char* prefix, const u_char* buffer, int size)
 {
 	static const char hex_chars[] = "0123456789abcdef";
 	char hex[MAX_DUMP_BUFFER_SIZE * 3 + 1];
 	char* hex_pos = hex;
-	
+
 	size = vod_min(size, MAX_DUMP_BUFFER_SIZE);
 	for (; size > 0; size--, buffer++)
 	{
@@ -291,7 +296,7 @@ log_buffer(unsigned level, vod_log_t* log, int err, const char* prefix, const u_
 		*hex_pos++ = ' ';
 	}
 	*hex_pos = '\0';
-	
+
 	vod_log_debug2(level, log, err, "%s %s", prefix, hex);
 }
 
@@ -361,12 +366,99 @@ int vod_get_int_print_len(uint64_t n);
 // is set or any other flag that implies it like "-mavx2"
 #define vod_get_number_of_set_bits32(i) __builtin_popcount(i)
 #define vod_get_number_of_set_bits64(i) __builtin_popcountll(i)
+#define vod_get_trailing_zeroes64(i) __builtin_ctzll(i)
 #else
 #define VOD_IMPLEMENT_BIT_COUNT
 uint32_t vod_get_number_of_set_bits32(uint32_t i);
 uint32_t vod_get_number_of_set_bits64(uint64_t i);
+uint32_t vod_get_trailing_zeroes64(uint64_t i);
 #endif
 #define vod_get_number_of_set_bits(i) ((sizeof(size_t) <= 4) ? vod_get_number_of_set_bits32(i) : vod_get_number_of_set_bits64(i))
+
+// bit sets
+// always assumes max_bits = n * 64.
+// -> n = max_bits / 64 (integer division)
+// -> residual elements are not handled!
+static vod_inline uint32_t
+vod_get_number_of_set_bits_in_mask(
+	uint64_t* mask,
+	uint32_t max_bits)
+{
+	uint32_t i;
+	uint32_t result = 0;
+	// due to inlining, the loop is unrolled and optimized
+	for (i = 0; i < max_bits / 64; i++)
+	{
+		result += vod_get_number_of_set_bits64(mask[i]);
+	}
+	return result;
+}
+
+static vod_inline bool_t
+vod_are_all_bits_set(
+	uint64_t* mask,
+	uint32_t max_bits)
+{
+	uint32_t i;
+	for (i = 0; i < max_bits / 64; i++)
+	{
+		if (mask[i] != ~(uint64_t)0)
+		{
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}
+
+static vod_inline bool_t
+vod_is_any_bit_set(
+	uint64_t* mask,
+	uint32_t max_bits)
+{
+	uint32_t i;
+	for (i = 0; i < max_bits / 64; i++)
+	{
+		if (mask[i] != (uint64_t)0)
+		{
+			return TRUE;
+		}
+	}
+
+	return FALSE;
+}
+
+static vod_inline int32_t
+vod_get_lowest_bit_set(
+	uint64_t* mask,
+	uint32_t max_bits)
+{
+	uint32_t i;
+	for (i = 0; max_bits / 64; i++)
+	{
+		if (mask[i] != (uint64_t)0)
+		{
+			return i * 64 + vod_get_trailing_zeroes64(mask[i]);
+		}
+	}
+
+	// well defined result in case no bit is set
+	return -1;
+}
+
+static vod_inline void
+vod_and_bits(
+	uint64_t* dst,
+	uint64_t* a,
+	uint64_t* b,
+	uint32_t max_bits)
+{
+	uint32_t i;
+	for (i = 0; i < vod_array_length_for_bits(max_bits); i++)
+	{
+		dst[i] = a[i] & b[i];
+	}
+}
 
 u_char* vod_append_hex_string(u_char* p, const u_char* buffer, uint32_t buffer_size);
 

--- a/vod/filters/concat_clip.c
+++ b/vod/filters/concat_clip.c
@@ -68,7 +68,7 @@ concat_clip_parse(
 	uint64_t original_clip_time;
 	uint64_t start;
 	uint64_t end;
-	uint32_t tracks_mask[MEDIA_TYPE_COUNT];
+	track_mask_t tracks_mask[MEDIA_TYPE_COUNT];
 	uint32_t min_index;
 	uint32_t max_index;
 	uint32_t clip_count;
@@ -426,10 +426,10 @@ concat_clip_parse(
 		cur_source->stripped_uri = cur_source->mapped_uri = dest_str;
 
 		vod_log_debug3(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
-			"concat_clip_parse: parsed clip source - path=%V tracks[v]=0x%uxD tracks[a]=0x%uxD",
+			"concat_clip_parse: parsed clip source - path=%V tracks[v]=0x%uxL tracks[a]=0x%uxL",
 			&cur_source->mapped_uri,
-			cur_source->tracks_mask[MEDIA_TYPE_VIDEO],
-			cur_source->tracks_mask[MEDIA_TYPE_AUDIO]);
+			cur_source->tracks_mask[MEDIA_TYPE_VIDEO][0],
+			cur_source->tracks_mask[MEDIA_TYPE_AUDIO][0]);
 
 		cur_source++;
 		if (cur_source >= sources_end)

--- a/vod/input/silence_generator.c
+++ b/vod/input/silence_generator.c
@@ -32,7 +32,7 @@ silence_generator_parse(
 	source->sequence = context->sequence;
 	source->range = context->range;
 	source->clip_time = context->clip_time;
-	source->tracks_mask[MEDIA_TYPE_AUDIO] = 1;
+	vod_set_bit(source->tracks_mask[MEDIA_TYPE_AUDIO], 0);
 
 	if (context->duration == UINT_MAX)
 	{
@@ -197,6 +197,6 @@ silence_generator_generate(
 
 media_generator_t silence_generator = {
 	VOD_CODEC_FLAG(AAC),
-	{ 0, 1, 0 },
+	{ {0}, {1}, {0} },
 	silence_generator_generate
 };

--- a/vod/language_code.h
+++ b/vod/language_code.h
@@ -6,7 +6,7 @@
 
 // constants
 #define LANG_ISO639_3_LEN (3)
-#define LANG_MASK_SIZE ((VOD_LANG_COUNT + 7) >> 3)
+#define LANG_MASK_SIZE vod_array_length_for_bits(VOD_LANG_COUNT)
 
 // macros
 #define iso639_3_str_to_int(x) \

--- a/vod/manifest_utils.h
+++ b/vod/manifest_utils.h
@@ -46,12 +46,12 @@ typedef struct {
 // functions
 vod_status_t manifest_utils_build_request_params_string(
 	request_context_t* request_context,
-	uint32_t* has_tracks,
+	track_mask_t* has_tracks,
 	uint32_t segment_index,
 	uint32_t sequences_mask,
 	sequence_tracks_mask_t* sequence_tracks_mask,
 	sequence_tracks_mask_t* sequence_tracks_mask_end,
-	uint32_t* tracks_mask,
+	track_mask_t* tracks_mask,
 	vod_str_t* result);
 
 u_char* manifest_utils_append_tracks_spec(

--- a/vod/media_clip.h
+++ b/vod/media_clip.h
@@ -77,7 +77,7 @@ struct media_clip_source_s {
 	media_clip_source_type_t source_type;
 	vod_str_t uri;				// original uri
 	uint64_t clip_from;
-	uint32_t tracks_mask[MEDIA_TYPE_COUNT];
+	track_mask_t tracks_mask[MEDIA_TYPE_COUNT];
 	uint32_t time_shift[MEDIA_TYPE_COUNT];
 	media_clip_source_enc_t encryption;
 
@@ -98,7 +98,7 @@ struct media_clip_source_s {
 
 typedef struct {
 	int codec_mask;
-	uint32_t track_mask[MEDIA_TYPE_COUNT];
+	track_mask_t tracks_mask[MEDIA_TYPE_COUNT];
 	vod_status_t(*generate)(
 		request_context_t* request_context,
 		media_parse_params_t* parse_params,

--- a/vod/media_format.h
+++ b/vod/media_format.h
@@ -160,7 +160,7 @@ typedef struct {
 
 typedef struct {
 	uint32_t* required_tracks_mask;
-	uint8_t* langs_mask;
+	uint64_t* langs_mask;
 	uint32_t clip_from;
 	uint32_t clip_to;
 	media_range_t* range;
@@ -319,7 +319,7 @@ typedef struct {
 
 	// metadata reader
 	vod_status_t(*init_metadata_reader)(
-		request_context_t* request_context, 
+		request_context_t* request_context,
 		vod_str_t* buffer,
 		size_t max_metadata_size,
 		void** ctx);

--- a/vod/media_format.h
+++ b/vod/media_format.h
@@ -11,10 +11,27 @@
 #define rescale_time(time, cur_scale, new_scale) ((((uint64_t)(time)) * (new_scale) + (cur_scale) / 2) / (cur_scale))
 #define rescale_time_neg(time, cur_scale, new_scale) ((time) >= 0 ? rescale_time(time, cur_scale, new_scale) : -rescale_time(-(time), cur_scale, new_scale))
 
+#define vod_track_mask_set_all_bits(mask) vod_set_all_bits((mask), MAX_TRACK_COUNT)
+#define vod_track_mask_reset_all_bits(mask) vod_reset_all_bits((mask), MAX_TRACK_COUNT)
+#define vod_track_mask_get_number_of_set_bits(mask) vod_get_number_of_set_bits_in_mask((mask), MAX_TRACK_COUNT)
+#define vod_track_mask_are_all_bits_set(mask) vod_are_all_bits_set((mask), MAX_TRACK_COUNT)
+#define vod_track_mask_is_any_bit_set(mask) vod_is_any_bit_set((mask), MAX_TRACK_COUNT)
+#define vod_track_mask_get_lowest_bit_set(mask) vod_get_lowest_bit_set((mask), MAX_TRACK_COUNT)
+#define vod_track_mask_and_bits(dst, a, b) vod_and_bits((dst), (a), (b), MAX_TRACK_COUNT)
+
 // constants
 #define MAX_CODEC_NAME_SIZE (64)
 #define MAX_FRAME_SIZE (10 * 1024 * 1024)
-#define MAX_TRACK_COUNT (1024)
+#ifdef NGX_VOD_MAX_TRACK_COUNT
+#if NGX_VOD_MAX_TRACK_COUNT % 64 != 0
+#error MAX_TRACK_COUNT must be a multiple of 64!
+#endif
+#define MAX_TRACK_COUNT (NGX_VOD_MAX_TRACK_COUNT)
+#define MAX_TRACK_INDEX_LEN (sizeof(ngx_value(NGX_VOD_MAX_TRACK_COUNT)) - 1)
+#else
+#define MAX_TRACK_COUNT (64)
+#define MAX_TRACK_INDEX_LEN (2)
+#endif
 #define MAX_DURATION_SEC (1000000)
 #define MAX_CLIP_DURATION (90000000)		// 25h
 #define MAX_SEQUENCE_DURATION (864000000)		// 10 days
@@ -150,6 +167,9 @@ enum {			// mp4 only
 	RTA_COUNT
 };
 
+// types
+typedef uint64_t track_mask_t[vod_array_length_for_bits(MAX_TRACK_COUNT)];
+
 // parse params
 typedef struct {
 	uint64_t start;			// relative to clip_from
@@ -159,7 +179,7 @@ typedef struct {
 } media_range_t;
 
 typedef struct {
-	uint32_t* required_tracks_mask;
+	track_mask_t* required_tracks_mask;
 	uint64_t* langs_mask;
 	uint32_t clip_from;
 	uint32_t clip_to;

--- a/vod/media_set.h
+++ b/vod/media_set.h
@@ -182,7 +182,7 @@ typedef struct {
 	uint32_t tracks_mask[MEDIA_TYPE_COUNT];
 	sequence_tracks_mask_t* sequence_tracks_mask;
 	sequence_tracks_mask_t* sequence_tracks_mask_end;
-	uint8_t* langs_mask;			// [LANG_MASK_SIZE]
+	uint64_t* langs_mask;			// [LANG_MASK_SIZE]
 	uint32_t version;
 	uint32_t width;
 	uint32_t height;

--- a/vod/media_set.h
+++ b/vod/media_set.h
@@ -168,7 +168,7 @@ typedef struct {
 
 typedef struct {
 	int32_t index;			// positive = sequence index (-f1), negative = index into sequence_ids (-s1)
-	uint32_t tracks_mask[MEDIA_TYPE_COUNT];
+	track_mask_t tracks_mask[MEDIA_TYPE_COUNT];
 } sequence_tracks_mask_t;
 
 typedef struct {
@@ -179,7 +179,7 @@ typedef struct {
 	uint32_t pts_delay;
 	uint32_t sequences_mask;
 	vod_str_t sequence_ids[MAX_SEQUENCE_IDS];
-	uint32_t tracks_mask[MEDIA_TYPE_COUNT];
+	track_mask_t tracks_mask[MEDIA_TYPE_COUNT];
 	sequence_tracks_mask_t* sequence_tracks_mask;
 	sequence_tracks_mask_t* sequence_tracks_mask_end;
 	uint64_t* langs_mask;			// [LANG_MASK_SIZE]

--- a/vod/media_set_parser.c
+++ b/vod/media_set_parser.c
@@ -905,7 +905,7 @@ media_set_parse_sequences(
 
 	if (request_params->sequence_ids[0].len == 0)
 	{
-		required_sequences_num = vod_get_number_of_set_bits(request_params->sequences_mask);
+		required_sequences_num = vod_get_number_of_set_bits32(request_params->sequences_mask);
 		required_sequences_num = vod_min(array->count, required_sequences_num);
 	}
 	else

--- a/vod/media_set_parser.c
+++ b/vod/media_set_parser.c
@@ -433,7 +433,7 @@ media_set_parse_tracks_spec(
 	void* dest)
 {
 	media_filter_parse_context_t* context = ctx;
-	uint32_t* tracks_mask = dest;
+	track_mask_t* tracks_mask = dest;
 	u_char* end_pos = value->v.str.data + value->v.str.len;
 
 	vod_memzero(tracks_mask, sizeof(tracks_mask[0]) * MEDIA_TYPE_COUNT);
@@ -648,10 +648,10 @@ media_set_parse_source(
 	context->base.sources_head = source;
 
 	vod_log_debug4(VOD_LOG_DEBUG_LEVEL, context->base.request_context->log, 0,
-		"media_set_parse_source: parsed clip source - path=%V tracks[v]=0x%uxD tracks[a]=0x%uxD, clipFrom=%uL", 
+		"media_set_parse_source: parsed clip source - path=%V tracks[v]=0x%uxL tracks[a]=0x%uxL, clipFrom=%uL",
 		&source->mapped_uri, 
-		source->tracks_mask[MEDIA_TYPE_VIDEO],
-		source->tracks_mask[MEDIA_TYPE_AUDIO],
+		source->tracks_mask[MEDIA_TYPE_VIDEO][0],
+		source->tracks_mask[MEDIA_TYPE_AUDIO][0],
 		source->clip_from);
 
 	*result = &source->base;

--- a/vod/mkv/mkv_format.c
+++ b/vod/mkv/mkv_format.c
@@ -788,7 +788,7 @@ mkv_metadata_parse(
 
 		// is this track required ?
 		track_index = track_indexes[media_type]++;
-		if ((parse_params->required_tracks_mask[media_type] & (1 << track_index)) == 0)
+		if (!vod_is_bit_set(parse_params->required_tracks_mask[media_type], track_index))
 		{
 			continue;
 		}
@@ -808,10 +808,10 @@ mkv_metadata_parse(
 			return VOD_BAD_DATA;
 		}
 
-		if (metadata->base.tracks.nelts >= MAX_TRACK_COUNT)
+		if (metadata->base.tracks.nelts > MAX_TRACK_COUNT)
 		{
 			vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-				"mkv_metadata_parse: track count exceeded the limit");
+				"mkv_metadata_parse: track count exceeded the limit of %i", (ngx_int_t)MAX_TRACK_COUNT);
 			return VOD_BAD_REQUEST;
 		}
 

--- a/vod/mp4/mp4_clipper.c
+++ b/vod/mp4/mp4_clipper.c
@@ -1506,7 +1506,7 @@ mp4_clipper_process_moov_atom_callback(void* ctx, atom_info_t* atom_info)
 	if (media_type != MEDIA_TYPE_NONE)
 	{
 		track_index = context->track_indexes[media_type]++;
-		if ((context->parse_params.required_tracks_mask[media_type] & (1 << track_index)) == 0)
+		if (!vod_is_bit_set(context->parse_params.required_tracks_mask[media_type], track_index))
 		{
 			return VOD_OK;
 		}

--- a/vod/mp4/mp4_parser.c
+++ b/vod/mp4/mp4_parser.c
@@ -2228,7 +2228,7 @@ mp4_parser_parse_audio_atoms(void* ctx, atom_info_t* atom_info)
 
 		channel_layout = mp4_parser_get_ac3_channel_layout(acmod, lfeon, 0);
 
-		context->media_info.u.audio.channels = vod_get_number_of_set_bits(channel_layout & NGX_MAX_UINT32_VALUE);
+		context->media_info.u.audio.channels = vod_get_number_of_set_bits64(channel_layout);
 		context->media_info.u.audio.channel_layout = channel_layout;
 		return VOD_OK;
 
@@ -2252,8 +2252,7 @@ mp4_parser_parse_audio_atoms(void* ctx, atom_info_t* atom_info)
 
 		channel_layout = mp4_parser_get_ac3_channel_layout(acmod, lfeon, chan_loc);
 
-		context->media_info.u.audio.channels = vod_get_number_of_set_bits(channel_layout & NGX_MAX_UINT32_VALUE) +
-			vod_get_number_of_set_bits(channel_layout >> 32);
+		context->media_info.u.audio.channels = vod_get_number_of_set_bits64(channel_layout);
 		context->media_info.u.audio.channel_layout = channel_layout;
 
 		// set the extra data to the contents of this atom, since it's used

--- a/vod/mp4/mp4_parser.c
+++ b/vod/mp4/mp4_parser.c
@@ -2863,7 +2863,7 @@ mp4_parser_process_moov_atom_callback(void* ctx, atom_info_t* atom_info)
 
 	// check whether we should include this track
 	track_index = context->track_indexes[metadata_parse_context.media_info.media_type]++;
-	if ((context->parse_params.required_tracks_mask[metadata_parse_context.media_info.media_type] & (1 << track_index)) == 0)
+	if (!vod_is_bit_set(context->parse_params.required_tracks_mask[metadata_parse_context.media_info.media_type], track_index))
 	{
 		return VOD_OK;
 	}
@@ -2926,10 +2926,10 @@ mp4_parser_process_moov_atom_callback(void* ctx, atom_info_t* atom_info)
 	}
 
 	// add to the result array
-	if (result->base.tracks.nelts >= MAX_TRACK_COUNT)
+	if (result->base.tracks.nelts > MAX_TRACK_COUNT)
 	{
 		vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-			"mp4_parser_process_moov_atom_callback: track count exceeded the limit");
+			"mp4_parser_process_moov_atom_callback: track count exceeded the limit of %i", (ngx_int_t)MAX_TRACK_COUNT);
 		return VOD_BAD_REQUEST;
 	}
 

--- a/vod/parse_utils.c
+++ b/vod/parse_utils.c
@@ -1,3 +1,4 @@
+#include "media_format.h"
 #include "parse_utils.h"
 
 static int
@@ -154,7 +155,7 @@ parse_utils_extract_uint32_token(u_char* start_pos, u_char* end_pos, uint32_t* r
 }
 
 u_char*
-parse_utils_extract_track_tokens(u_char* start_pos, u_char* end_pos, uint32_t* result)
+parse_utils_extract_track_tokens(u_char* start_pos, u_char* end_pos, track_mask_t* result)
 {
 	uint32_t stream_index;
 	u_char* next_pos;
@@ -165,7 +166,7 @@ parse_utils_extract_track_tokens(u_char* start_pos, u_char* end_pos, uint32_t* r
 	{
 		for (media_type = 0; media_type < MEDIA_TYPE_COUNT; media_type++)
 		{
-			result[media_type] = 1;
+			vod_set_bit(result[media_type], 0);
 		}
 		return start_pos;
 	}
@@ -193,11 +194,11 @@ parse_utils_extract_track_tokens(u_char* start_pos, u_char* end_pos, uint32_t* r
 		if (stream_index == 0)
 		{
 			// no index => all streams of the media type
-			result[media_type] = 0xffffffff;
+			vod_track_mask_set_all_bits(result[media_type]);
 		}
 		else
 		{
-			result[media_type] |= (1 << (stream_index - 1));
+			vod_set_bit(result[media_type], stream_index - 1);
 		}
 
 		start_pos = next_pos;

--- a/vod/parse_utils.h
+++ b/vod/parse_utils.h
@@ -3,6 +3,7 @@
 
 // includes
 #include "common.h"
+#include "media_format.h"
 
 // functions
 vod_status_t parse_utils_parse_guid_string(vod_str_t* str, u_char* output);
@@ -13,6 +14,6 @@ vod_status_t parse_utils_parse_variable_base64_string(vod_pool_t* pool, vod_str_
 
 u_char* parse_utils_extract_uint32_token(u_char* start_pos, u_char* end_pos, uint32_t* result);
 
-u_char* parse_utils_extract_track_tokens(u_char* start_pos, u_char* end_pos, uint32_t* result);
+u_char* parse_utils_extract_track_tokens(u_char* start_pos, u_char* end_pos, track_mask_t* result);
 
 #endif // __PARSE_UTILS_H__


### PR DESCRIPTION
The track selection is handled by a bit mask. 
This mask was 32 bit wide so the maximum number of streamable tracks was limited to 32.
If the video contained more tracks, the logic in [mp4_parser.c:2867](https://github.com/JoelLinn/nginx-vod-module/blob/ce273ec54d12bd2141297370dd95b9e6387dcfcc/vod/mp4/mp4_parser.c#L2867) would wrap and try to stream more than one track at once for indexes greater than 31.

This patch uses an array of `uint64_t` as bitmask.
The maximum number of tracks is selected at compile time. It can be increased by adding `-DNGX_VOD_MAX_TRACK_COUNT=256` to the cc configuration options and defaults to 64. (This mechanism is used by other nginx modules as well, for example lua.)

A number of macros and inline functions was added to the header which already defined the existing bitset macros. They are needed to simplify operations like `(mask1 & mask2) != 0`. With `-O2` or greater they are optimized and the mentioned operation compiles to only 3 x86 instructions (for up to 256 tracks) if vector extensions are enabled (`-mavx2`).

I had to add a typedef for the track mask array in order to avoid array type decay when using multi dimensional arrays as function parameters (like `size_t tracks_mask[MEDIA_TYPE_COUNT][MASK_ARRAY_SIZE]`).

With the python script `generate_many_tracks.py` it's possible to create a mp4 with many language tracks (≈600), which I successfully tested with `NGX_VOD_MAX_TRACK_COUNT=640` and the [dash reference client](http://reference.dashif.org/dash.js/nightly/samples/dash-if-reference-player/index.html) (vlc seems to have a bug with such a high number of tracks). Not that we need that amount of tracks but the test should prove that this PR fixes the underlying issue for good.

Old text:
> This patch widens the masks to 64 bits.
> It also changes `MAX_TRACK_COUNT` to `64` in order to catch unsupported files deterministically.
> I am not 100% sure about changing `MAX_TRACK_COUNT` though, I never looked into mixing - it might be possible that it's more sensible to keep it at `1024` and add another check somewhere else.
> 
> In our use case, we have one source language audio track and two additional tracks for each  language (translation only + translation with quiet source language track). That effectively limits us to only 16 languages.
> 
> **Edit:**
> We might hit the 64 track limit at a later point, but fixing that requires larger changes so this will do for now.
> I would prefer to discuss the needed changes with maintainers before implementation.
> 