### PR TITLE
Remove blank nodes when parsing dfxp subtitles

### DIFF
--- a/vod/subtitle/dfxp_format.c
+++ b/vod/subtitle/dfxp_format.c
@@ -430,7 +430,7 @@ dfxp_parse(
 		return VOD_ALLOC_FAILED;
 	}
 
-	xmlCtxtUseOptions(ctxt, XML_PARSE_RECOVER | XML_PARSE_NOWARNING | XML_PARSE_NONET);
+	xmlCtxtUseOptions(ctxt, XML_PARSE_RECOVER | XML_PARSE_NOWARNING | XML_PARSE_NONET | XML_PARSE_NOBLANKS);
 	
 	ctxt->sax->setDocumentLocator = NULL;
 	ctxt->sax->error = dfxp_xml_sax_error;


### PR DESCRIPTION
When parsing DFXP/TTML subtitles to later convert to VTT, blank nodes should be ignored. For instance if you have the following in your dfxp subtitle :
```
<p begin="00:01:37.437" end="00:01:40.697">
    <span tts:backgroundColor="#000000" tts:color="#ffffff">Sentence 1</span>
    <br></br>
    <span tts:backgroundColor="#000000" tts:color="#ffffff">Sentence 2</span>
</p>
```

The transformed VTT output looks like :
```
00:01:37.437 --> 00:01:40.697
Sentence 1
                

                Sentence 2
```

Whereas the expected result should be :
```
00:01:37.437 --> 00:01:40.697
Sentence 1
Sentence 2
```
