### PR TITLE
make max_frame_count configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1121,6 +1121,20 @@ Sets the maximum supported video metadata size (for MP4 - moov atom size)
 
 Sets the limit on the total size of the frames of a single segment
 
+#### vod_max_frame_count
+* **syntax**: `vod_max_frame_count count`
+* **default**: `1048576`
+* **context**: `http`, `server`, `location`
+
+Sets the limit on the total count of the frames read to serve non segment (e.g. playlist) request.
+
+#### vod_segment_max_frame_count
+* **syntax**: `vod_segment_max_frame_count count`
+* **default**: `65536`
+* **context**: `http`, `server`, `location`
+
+Sets the limit on the total count of the frames read to serve segment request.
+
 #### vod_cache_buffer_size
 * **syntax**: `vod_cache_buffer_size size`
 * **default**: `256K`

--- a/ngx_http_vod_conf.c
+++ b/ngx_http_vod_conf.c
@@ -206,8 +206,8 @@ ngx_http_vod_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 	ngx_conf_merge_size_value(conf->initial_read_size, prev->initial_read_size, 4096);
 	ngx_conf_merge_size_value(conf->max_metadata_size, prev->max_metadata_size, 128 * 1024 * 1024);
 	ngx_conf_merge_size_value(conf->max_frames_size, prev->max_frames_size, 16 * 1024 * 1024);
-	ngx_conf_merge_size_value(conf->max_frame_count, prev->max_frame_count, 1024 * 1024);
-	ngx_conf_merge_size_value(conf->segment_max_frame_count, prev->segment_max_frame_count, 64 * 1024);
+	ngx_conf_merge_uint_value(conf->max_frame_count, prev->max_frame_count, 1024 * 1024);
+	ngx_conf_merge_uint_value(conf->segment_max_frame_count, prev->segment_max_frame_count, 64 * 1024);
 	ngx_conf_merge_size_value(conf->cache_buffer_size, prev->cache_buffer_size, 256 * 1024);
 	ngx_conf_merge_size_value(conf->max_upstream_headers_size, prev->max_upstream_headers_size, 4 * 1024);
 

--- a/ngx_http_vod_conf.c
+++ b/ngx_http_vod_conf.c
@@ -85,6 +85,8 @@ ngx_http_vod_create_loc_conf(ngx_conf_t *cf)
 	conf->initial_read_size = NGX_CONF_UNSET_SIZE;
 	conf->max_metadata_size = NGX_CONF_UNSET_SIZE;
 	conf->max_frames_size = NGX_CONF_UNSET_SIZE;
+	conf->max_frame_count = NGX_CONF_UNSET_UINT;
+	conf->segment_max_frame_count = NGX_CONF_UNSET_UINT;
 	conf->cache_buffer_size = NGX_CONF_UNSET_SIZE;
 	conf->max_upstream_headers_size = NGX_CONF_UNSET_SIZE;
 	conf->ignore_edit_list = NGX_CONF_UNSET;
@@ -204,9 +206,11 @@ ngx_http_vod_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 	ngx_conf_merge_size_value(conf->initial_read_size, prev->initial_read_size, 4096);
 	ngx_conf_merge_size_value(conf->max_metadata_size, prev->max_metadata_size, 128 * 1024 * 1024);
 	ngx_conf_merge_size_value(conf->max_frames_size, prev->max_frames_size, 16 * 1024 * 1024);
+	ngx_conf_merge_size_value(conf->max_frame_count, prev->max_frame_count, 1024 * 1024);
+	ngx_conf_merge_size_value(conf->segment_max_frame_count, prev->segment_max_frame_count, 64 * 1024);
 	ngx_conf_merge_size_value(conf->cache_buffer_size, prev->cache_buffer_size, 256 * 1024);
 	ngx_conf_merge_size_value(conf->max_upstream_headers_size, prev->max_upstream_headers_size, 4 * 1024);
-	
+
 	if (conf->output_buffer_pool == NULL)
 	{
 		conf->output_buffer_pool = prev->output_buffer_pool;
@@ -1027,6 +1031,20 @@ ngx_command_t ngx_http_vod_commands[] = {
 	ngx_conf_set_size_slot,
 	NGX_HTTP_LOC_CONF_OFFSET,
 	offsetof(ngx_http_vod_loc_conf_t, max_frames_size),
+	NULL },
+
+	{ ngx_string("vod_max_frame_count"),
+	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+	ngx_conf_set_num_slot,
+	NGX_HTTP_LOC_CONF_OFFSET,
+	offsetof(ngx_http_vod_loc_conf_t, max_frame_count),
+	NULL },
+
+	{ ngx_string("vod_segment_max_frame_count"),
+	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+	ngx_conf_set_num_slot,
+	NGX_HTTP_LOC_CONF_OFFSET,
+	offsetof(ngx_http_vod_loc_conf_t, segment_max_frame_count),
 	NULL },
 
 	{ ngx_string("vod_cache_buffer_size"),

--- a/ngx_http_vod_conf.h
+++ b/ngx_http_vod_conf.h
@@ -51,8 +51,8 @@ struct ngx_http_vod_loc_conf_s {
 	size_t initial_read_size;
 	size_t max_metadata_size;
 	size_t max_frames_size;
-	ngx_int_t max_frame_count;
-	ngx_int_t segment_max_frame_count;
+	ngx_uint_t max_frame_count;
+	ngx_uint_t segment_max_frame_count;
 	size_t cache_buffer_size;
 	buffer_pool_t* output_buffer_pool;
 	size_t max_upstream_headers_size;

--- a/ngx_http_vod_conf.h
+++ b/ngx_http_vod_conf.h
@@ -51,6 +51,8 @@ struct ngx_http_vod_loc_conf_s {
 	size_t initial_read_size;
 	size_t max_metadata_size;
 	size_t max_frames_size;
+	ngx_int_t max_frame_count;
+	ngx_int_t segment_max_frame_count;
 	size_t cache_buffer_size;
 	buffer_pool_t* output_buffer_pool;
 	size_t max_upstream_headers_size;

--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -48,9 +48,6 @@
 #define OPEN_FILE_FALLBACK_ENABLED (0x80000000)
 #define MAX_STALE_RETRIES (2)
 
-#define SEGMENT_REQUEST_MAX_FRAME_COUNT (64 * 1024)
-#define NON_SEGMENT_REQUEST_MAX_FRAME_COUNT (1024 * 1024)
-
 enum {
 	// mapping state machine
 	STATE_MAP_INITIAL,
@@ -1512,7 +1509,7 @@ ngx_http_vod_init_parse_params_frames(
 	{
 		request_context->simulation_only = TRUE;
 
-		parse_params->max_frame_count = NON_SEGMENT_REQUEST_MAX_FRAME_COUNT;
+		parse_params->max_frame_count = ctx->submodule_context.conf->max_frame_count;
 		range->timescale = 1000;
 		range->original_clip_time = 0;
 		range->start = 0;
@@ -1530,7 +1527,7 @@ ngx_http_vod_init_parse_params_frames(
 
 	request_context->simulation_only = FALSE;
 
-	parse_params->max_frame_count = SEGMENT_REQUEST_MAX_FRAME_COUNT;
+	parse_params->max_frame_count = ctx->submodule_context.conf->segment_max_frame_count;
 
 	if (cur_source->range != NULL)
 	{
@@ -3689,11 +3686,11 @@ ngx_http_vod_run_state_machine(ngx_http_vod_ctx_t *ctx)
 
 			if ((ctx->request->request_class & (REQUEST_CLASS_MANIFEST | REQUEST_CLASS_OTHER)) != 0)
 			{
-				max_frame_count = NON_SEGMENT_REQUEST_MAX_FRAME_COUNT;
+				max_frame_count = ctx->submodule_context.conf->max_frame_count;
 			}
 			else
 			{
-				max_frame_count = SEGMENT_REQUEST_MAX_FRAME_COUNT;
+				max_frame_count = ctx->submodule_context.conf->segment_max_frame_count;
 			}
 
 #if (NGX_HAVE_LIB_AV_CODEC)


### PR DESCRIPTION
Fixes https://github.com/kaltura/nginx-vod-module/issues/1057

I thought about making this 2-argument config option - let me know if you prefer this way.

**I didn't run any tests yet, because currently I don't have any ENV to debug/compile nginx/openresty. If anyone can check this it'll be great, if not I will do this next few days.**

EDIT: I can revert all those whitespace changes (all my editors and settings remove trailing whitespaces by default) if it's a problem.