### PR TITLE
BANDWIDTH / AVERAGE-BANDWIDTH #946

### DIFF
--- a/vod/hls/hls_muxer.h
+++ b/vod/hls/hls_muxer.h
@@ -112,4 +112,14 @@ vod_status_t hls_muxer_simulate_get_iframes(
 	hls_get_iframe_positions_callback_t callback,
 	void* context);
 
+
+vod_status_t hls_muxer_simulate_get_segment_sizes(
+        request_context_t* request_context,
+        segment_durations_t* segment_durations,
+        hls_mpegts_muxer_conf_t* muxer_conf,
+        hls_encryption_params_t* encryption_params,
+        media_set_t* media_set,
+        vod_array_t* segments_sizes,
+        void* context);
+
 #endif // __HLS_MUXER_H__

--- a/vod/hls/hls_muxer.h
+++ b/vod/hls/hls_muxer.h
@@ -119,7 +119,7 @@ vod_status_t hls_muxer_simulate_get_segment_sizes(
         hls_mpegts_muxer_conf_t* muxer_conf,
         hls_encryption_params_t* encryption_params,
         media_set_t* media_set,
-        vod_array_t* segments_sizes,
-        void* context);
+        uint32_t* bandwidth,
+        uint32_t* avg_bandwidth);
 
 #endif // __HLS_MUXER_H__

--- a/vod/hls/m3u8_builder.h
+++ b/vod/hls/m3u8_builder.h
@@ -41,6 +41,8 @@ vod_status_t m3u8_builder_build_master_playlist(
 	vod_uint_t encryption_method,
 	vod_str_t* base_url,
 	media_set_t* media_set,
+    hls_mpegts_muxer_conf_t* muxer_conf,
+    hls_encryption_params_t* encryption_params,
 	vod_str_t* result);
 
 vod_status_t m3u8_builder_build_index_playlist(


### PR DESCRIPTION
Hi @erankor,

I got a very early proof of concept here. It works for my single test file - not enough but a start. 
The code that creates the i-frame playlist was transformed to compute segment sizes and (AVERAGE-)BANDWIDTH. 
I believe I added a few too many things to the hls_master_request in ngx_http_vod_hls.c - that might introduce a performance penalty. But it's hard for me to understand which REQUEST and PARSE flags are actually required.

As I don't have a lot of experience with the plugin: Is this approach something you'd support? 