### PR TITLE
Fix compilation with libavfilter of ffmpeg >= 5.1

### DIFF
--- a/vod/filters/audio_filter.c
+++ b/vod/filters/audio_filter.c
@@ -315,7 +315,11 @@ audio_filter_init_source(
 		decoder->time_base.den,
 		decoder->sample_rate,
 		av_get_sample_fmt_name(decoder->sample_fmt),
+#if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(8, 44, 100)
+		decoder->ch_layout.u.mask);
+#else
 		decoder->channel_layout);
+#endif
 
 	avrc = avfilter_graph_create_filter(
 		&source->buffer_src,
@@ -732,8 +736,13 @@ audio_filter_alloc_state(
 	}
 	else
 	{
+#if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(8, 44, 100)
+		encoder_params.channels = sink_link->ch_layout.nb_channels;
+		encoder_params.channel_layout = sink_link->ch_layout.u.mask;
+#else
 		encoder_params.channels = sink_link->channels;
 		encoder_params.channel_layout = sink_link->channel_layout;
+#endif
 		encoder_params.sample_rate = sink_link->sample_rate;
 		encoder_params.timescale = sink_link->time_base.den;
 		encoder_params.bitrate = output_track->media_info.bitrate;

--- a/vod/hds/hds_amf0_encoder.c
+++ b/vod/hds/hds_amf0_encoder.c
@@ -127,7 +127,6 @@ hds_amf0_write_metadata(u_char* p, media_set_t* media_set, media_track_t** track
 	uint64_t duration;
 	uint32_t timescale;
 	uint32_t count;
-	uint32_t bitrate = 0;
 	uint8_t sound_format;
 
 	count = AMF0_COMMON_FIELDS_COUNT;
@@ -155,7 +154,6 @@ hds_amf0_write_metadata(u_char* p, media_set_t* media_set, media_track_t** track
 	if (tracks[MEDIA_TYPE_VIDEO] != NULL)
 	{
 		media_info = &tracks[MEDIA_TYPE_VIDEO]->media_info;
-		bitrate += media_info->bitrate;
 		p = hds_amf0_append_array_number_value(p, &amf0_width, media_info->u.video.width);
 		p = hds_amf0_append_array_number_value(p, &amf0_height, media_info->u.video.height);
 		p = hds_amf0_append_array_number_value(p, &amf0_videodatarate, (double)media_info->bitrate / 1000.0);
@@ -166,7 +164,6 @@ hds_amf0_write_metadata(u_char* p, media_set_t* media_set, media_track_t** track
 	if (tracks[MEDIA_TYPE_AUDIO] != NULL)
 	{
 		media_info = &tracks[MEDIA_TYPE_AUDIO]->media_info;
-		bitrate += media_info->bitrate;
 		p = hds_amf0_append_array_number_value(p, &amf0_audiodatarate, (double)media_info->bitrate / 1000.0);
 		p = hds_amf0_append_array_number_value(p, &amf0_audiosamplerate, media_info->u.audio.sample_rate);
 		p = hds_amf0_append_array_number_value(p, &amf0_audiosamplesize, media_info->u.audio.bits_per_sample);


### PR DESCRIPTION
The previous PR #1410 apparently did not fix compilation if libavfilter is used. @erankor 
However I am not using nginx-vod in an environment that requires filtering so it's hard to test for me, second opinion needed.

@pgassmann fyi