### PR TITLE
Check libavcodec version for AV1 codec definition

### DIFF
--- a/vod/thumb/thumb_grabber.c
+++ b/vod/thumb/thumb_grabber.c
@@ -55,7 +55,7 @@ static codec_id_mapping_t codec_mappings[] = {
 	{ VOD_CODEC_ID_HEVC, AV_CODEC_ID_H265, "h265" },
 	{ VOD_CODEC_ID_VP8, AV_CODEC_ID_VP8, "vp8" },
 	{ VOD_CODEC_ID_VP9, AV_CODEC_ID_VP9, "vp9" },
-#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(60, 16, 100)
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57, 25, 0)
 	{ VOD_CODEC_ID_AV1, AV_CODEC_ID_AV1, "av1" },
 #endif
 };

--- a/vod/thumb/thumb_grabber.c
+++ b/vod/thumb/thumb_grabber.c
@@ -55,7 +55,9 @@ static codec_id_mapping_t codec_mappings[] = {
 	{ VOD_CODEC_ID_HEVC, AV_CODEC_ID_H265, "h265" },
 	{ VOD_CODEC_ID_VP8, AV_CODEC_ID_VP8, "vp8" },
 	{ VOD_CODEC_ID_VP9, AV_CODEC_ID_VP9, "vp9" },
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(60, 16, 100)
 	{ VOD_CODEC_ID_AV1, AV_CODEC_ID_AV1, "av1" },
+#endif
 };
 
 void

--- a/vod/thumb/thumb_grabber.c
+++ b/vod/thumb/thumb_grabber.c
@@ -55,7 +55,7 @@ static codec_id_mapping_t codec_mappings[] = {
 	{ VOD_CODEC_ID_HEVC, AV_CODEC_ID_H265, "h265" },
 	{ VOD_CODEC_ID_VP8, AV_CODEC_ID_VP8, "vp8" },
 	{ VOD_CODEC_ID_VP9, AV_CODEC_ID_VP9, "vp9" },
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 25, 0)
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 89, 100)
 	{ VOD_CODEC_ID_AV1, AV_CODEC_ID_AV1, "av1" },
 #endif
 };

--- a/vod/thumb/thumb_grabber.c
+++ b/vod/thumb/thumb_grabber.c
@@ -55,7 +55,7 @@ static codec_id_mapping_t codec_mappings[] = {
 	{ VOD_CODEC_ID_HEVC, AV_CODEC_ID_H265, "h265" },
 	{ VOD_CODEC_ID_VP8, AV_CODEC_ID_VP8, "vp8" },
 	{ VOD_CODEC_ID_VP9, AV_CODEC_ID_VP9, "vp9" },
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57, 25, 0)
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 25, 0)
 	{ VOD_CODEC_ID_AV1, AV_CODEC_ID_AV1, "av1" },
 #endif
 };


### PR DESCRIPTION
After merging https://github.com/kaltura/nginx-vod-module/pull/1461, compilation is fail with old ffmpeg. the AV1 codec is only supporting from libformat 60.16.100 (ffmpeg 6) - https://github.com/FFmpeg/FFmpeg/commit/7a5e9a68b0895e68665e4fb329801a0f5820d856