### PR TITLE
mkv fixes and laces support

### DIFF
--- a/vod/common.h
+++ b/vod/common.h
@@ -80,6 +80,9 @@
 #define vod_log_debug2(level, log, err, fmt, arg1, arg2)
 #define vod_log_debug3(level, log, err, fmt, arg1, arg2, arg3)
 #define vod_log_debug4(level, log, err, fmt, arg1, arg2, arg3, arg4)
+#define vod_log_debug5(level, log, err, fmt, arg1, arg2, arg3, arg4, arg5)
+#define vod_log_debug6(level, log, err, fmt, arg1, arg2, arg3, arg4, arg5, arg6)
+#define vod_log_debug7(level, log, err, fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 
 typedef int bool_t;
 typedef int vod_status_t;
@@ -263,6 +266,15 @@ void vod_log_error(vod_uint_t level, vod_log_t *log, int err,
 
 #define vod_log_debug4(level, log, err, fmt, arg1, arg2, arg3, arg4) \
 		ngx_log_debug4(level, log, err, fmt, arg1, arg2, arg3, arg4)
+
+#define vod_log_debug5(level, log, err, fmt, arg1, arg2, arg3, arg4, arg5) \
+		ngx_log_debug5(level, log, err, fmt, arg1, arg2, arg3, arg4, arg5)
+
+#define vod_log_debug6(level, log, err, fmt, arg1, arg2, arg3, arg4, arg5, arg6) \
+		ngx_log_debug6(level, log, err, fmt, arg1, arg2, arg3, arg4, arg5, arg6)
+
+#define vod_log_debug7(level, log, err, fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7) \
+		ngx_log_debug7(level, log, err, fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 
 #define vod_errno ngx_errno
 

--- a/vod/common.h
+++ b/vod/common.h
@@ -98,6 +98,7 @@ void vod_log_error(vod_uint_t level, vod_log_t *log, int err,
 
 #define VOD_INT64_LEN NGX_INT64_LEN
 #define VOD_INT32_LEN NGX_INT32_LEN
+#define VOD_MAX_UINT32_VALUE NGX_MAX_UINT32_VALUE
 #define VOD_MAX_SIZE_T_VALUE NGX_MAX_SIZE_T_VALUE
 #define VOD_MAX_OFF_T_VALUE NGX_MAX_OFF_T_VALUE
 

--- a/vod/mkv/ebml.c
+++ b/vod/mkv/ebml.c
@@ -97,9 +97,10 @@ ebml_read_num(ebml_context_t* context, uint64_t* result, size_t max_size, int re
 }
 
 static vod_status_t
-ebml_read_size(ebml_context_t* context, uint64_t* result)
+ebml_read_size(ebml_context_t* context, uint64_t* result, bool_t truncate)
 {
 	vod_status_t rc;
+	uint64_t left;
 
 	rc = ebml_read_num(context, result, 8, 1);
 	if (rc < 0)
@@ -109,19 +110,28 @@ ebml_read_size(ebml_context_t* context, uint64_t* result)
 		return rc;
 	}
 
+	left = context->end_pos - context->cur_pos;
 	if (is_unknown_size(*result, rc))
 	{
-		*result = context->end_pos - context->cur_pos;
-	}
-	else if (*result > (uint64_t)(context->end_pos - context->cur_pos))
-	{
-		vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
-			"ebml_read_size: size %uL greater than the remaining stream bytes %uL", 
-			*result, (uint64_t)(context->end_pos - context->cur_pos));
-		return VOD_BAD_DATA;
+		*result = left;
+		return VOD_OK;
 	}
 
-	return VOD_OK;
+	if (*result <= left)
+	{
+		return VOD_OK;
+	}
+
+	if (truncate)
+	{
+		*result = left;
+		return VOD_OK;
+	}
+
+	vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
+		"ebml_read_size: size %uL greater than the remaining stream bytes %uL",
+		*result, left);
+	return VOD_BAD_DATA;
 }
 
 static vod_status_t
@@ -194,9 +204,10 @@ ebml_parse_element(ebml_context_t* context, ebml_spec_t* spec, void* dest)
 	uint64_t size;
 	void* cur_dest;
 	vod_status_t rc;
+	ebml_type_t type;
 
 	// size
-	rc = ebml_read_size(context, &size);
+	rc = ebml_read_size(context, &size, spec->type & EBML_TRUNCATE_SIZE);
 	if (rc != VOD_OK)
 	{
 		vod_log_debug1(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
@@ -210,7 +221,8 @@ ebml_parse_element(ebml_context_t* context, ebml_spec_t* spec, void* dest)
 		return VOD_OK;
 	}
 
-	max_size = ebml_max_sizes[spec->type];
+	type = spec->type & ~EBML_TRUNCATE_SIZE;
+	max_size = ebml_max_sizes[type];
 	if (max_size && size > max_size)
 	{
 		vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
@@ -220,7 +232,7 @@ ebml_parse_element(ebml_context_t* context, ebml_spec_t* spec, void* dest)
 
 	cur_dest = (u_char*)dest + spec->offset;
 
-	switch (spec->type)
+	switch (type)
 	{
 	case EBML_UINT:
 		rc = ebml_read_uint(context, size, cur_dest);

--- a/vod/mkv/ebml.c
+++ b/vod/mkv/ebml.c
@@ -261,9 +261,9 @@ ebml_parse_element(ebml_context_t* context, ebml_spec_t* spec, void* dest)
 		break;
 
 	case EBML_MASTER:
-		next_context.request_context = context->request_context;
-		next_context.cur_pos = context->cur_pos + size;
-		next_context.end_pos = context->end_pos;
+		next_context = *context;
+		next_context.cur_pos += size;
+
 		context->end_pos = next_context.cur_pos;
 		rc = ebml_parse_master(context, spec->child, cur_dest);
 		if (rc != VOD_OK)
@@ -276,9 +276,9 @@ ebml_parse_element(ebml_context_t* context, ebml_spec_t* spec, void* dest)
 		return VOD_OK;
 
 	case EBML_CUSTOM:
-		next_context.request_context = context->request_context;
-		next_context.cur_pos = context->cur_pos + size;
-		next_context.end_pos = context->end_pos;
+		next_context = *context;
+		next_context.cur_pos += size;
+
 		context->end_pos = next_context.cur_pos;
 		parser = spec->child;
 		rc = parser(context, spec, cur_dest);

--- a/vod/mkv/ebml.h
+++ b/vod/mkv/ebml.h
@@ -7,6 +7,8 @@
 #define ebml_read_id(context, id) ebml_read_num(context, id, 4, 0)
 #define is_unknown_size(num, num_bytes) ((num) + 1 == 1ULL << (7 * (num_bytes)))
 
+#define EBML_TRUNCATE_SIZE 0x80
+
 // typedefs
 typedef enum {
 	EBML_NONE,

--- a/vod/mkv/ebml.h
+++ b/vod/mkv/ebml.h
@@ -24,6 +24,7 @@ typedef struct {
 	request_context_t* request_context;
 	const u_char* cur_pos;
 	const u_char* end_pos;
+	int64_t offset_delta;
 } ebml_context_t;
 
 typedef struct {

--- a/vod/mkv/mkv_defs.c
+++ b/vod/mkv/mkv_defs.c
@@ -6,7 +6,7 @@
 mkv_codec_type_t mkv_codec_types[] = {
 	// video
 	{ vod_string("V_MPEG4/ISO/AVC"),	VOD_CODEC_ID_AVC,	FORMAT_AVC1,	TRUE },
-	{ vod_string("V_MPEGH/ISO/HEVC"),	VOD_CODEC_ID_HEVC,	FORMAT_HEV1,	TRUE },
+	{ vod_string("V_MPEGH/ISO/HEVC"),	VOD_CODEC_ID_HEVC,	FORMAT_HVC1,	TRUE },
 	{ vod_string("V_VP8"),				VOD_CODEC_ID_VP8,	0,				FALSE },
 	{ vod_string("V_VP9"),				VOD_CODEC_ID_VP9,	0,				FALSE },
 	{ vod_string("V_AV1"),				VOD_CODEC_ID_AV1,	0,				FALSE },
@@ -15,7 +15,11 @@ mkv_codec_type_t mkv_codec_types[] = {
 	{ vod_string("A_AAC"),				VOD_CODEC_ID_AAC,	FORMAT_MP4A,	TRUE },
 	{ vod_string("A_MPEG/L3"),			VOD_CODEC_ID_MP3,	FORMAT_MP4A,	FALSE },
 	{ vod_string("A_VORBIS"),			VOD_CODEC_ID_VORBIS,0,				TRUE },
-	{ vod_string("A_OPUS"),				VOD_CODEC_ID_OPUS,	0,				TRUE },
-	
+	{ vod_string("A_OPUS"),				VOD_CODEC_ID_OPUS,	FORMAT_OPUS,	TRUE },
+	{ vod_string("A_AC3"),				VOD_CODEC_ID_AC3,	FORMAT_AC3,		FALSE },
+	{ vod_string("A_EAC3"),				VOD_CODEC_ID_EAC3,	FORMAT_EAC3,	FALSE },
+	{ vod_string("A_DTS"),				VOD_CODEC_ID_DTS,	0,				TRUE },
+	{ vod_string("A_FLAC"),				VOD_CODEC_ID_FLAC,	FORMAT_FLAC,	TRUE },
+
 	{ vod_null_string, 0, 0, FALSE }
 };

--- a/vod/mkv/mkv_defs.h
+++ b/vod/mkv/mkv_defs.h
@@ -66,6 +66,7 @@
 #define MKV_ID_SIMPLEBLOCK			(0xA3)
 #define MKV_ID_BLOCKGROUP			(0xA0)
 #define MKV_ID_BLOCK				(0xA1)
+#define MKV_ID_REFERENCEBLOCK		(0xFB)
 #define MKV_ID_CLUSTER				(0x1F43B675)
 
 // sections

--- a/vod/mkv/mkv_defs.h
+++ b/vod/mkv/mkv_defs.h
@@ -64,6 +64,8 @@
 // cluster
 #define MKV_ID_CLUSTERTIMECODE		(0xE7)
 #define MKV_ID_SIMPLEBLOCK			(0xA3)
+#define MKV_ID_BLOCKGROUP			(0xA0)
+#define MKV_ID_BLOCK				(0xA1)
 #define MKV_ID_CLUSTER				(0x1F43B675)
 
 // sections

--- a/vod/mkv/mkv_format.c
+++ b/vod/mkv/mkv_format.c
@@ -1302,12 +1302,12 @@ static vod_status_t
 mkv_parse_laces(ebml_context_t* context, uint8_t flags, uint32_t* lace_sizes)
 {
 	vod_status_t rc;
-	size_t total;
 	uint64_t num;
+	int64_t delta;
+	size_t total;
 	uint32_t laces;
 	uint32_t size;
 	uint32_t i;
-	int64_t delta;
 	uint8_t lace_type;
 	u_char cur;
 
@@ -1330,12 +1330,13 @@ mkv_parse_laces(ebml_context_t* context, uint8_t flags, uint32_t* lace_sizes)
 	laces = *context->cur_pos + 1;
 	context->cur_pos++;
 
+	total = 0;
+
 	switch (lace_type)
 	{
 	case 0x1: // xiph
 		vod_memzero(lace_sizes, (laces - 1) * sizeof(lace_sizes[0]));
 
-		total = 0;
 		for (i = 0; i < laces - 1; i++)
 		{
 			do

--- a/vod/mkv/mkv_format.c
+++ b/vod/mkv/mkv_format.c
@@ -1007,7 +1007,7 @@ mkv_get_read_frames_request(
 	uint64_t done_tracks_mask;
 	uint64_t all_tracks_mask;
 	uint64_t cur_track_mask;
-	uint64_t initial_time = 0;
+	uint64_t initial_time;
 	mkv_index_t prev_index;
 	mkv_index_t index;
 	vod_status_t rc;
@@ -1017,7 +1017,10 @@ mkv_get_read_frames_request(
 	read_req->read_offset = ULLONG_MAX;
 	read_req->flags = 0;
 
+	initial_time = 0;
 	prev_index.cluster_pos = ULLONG_MAX;
+	prev_index.time = 0;
+
 	seen_tracks_mask = 0;
 	done_tracks_mask = 0;
 

--- a/vod/mkv/mkv_format.c
+++ b/vod/mkv/mkv_format.c
@@ -1007,7 +1007,7 @@ mkv_get_read_frames_request(
 	uint64_t done_tracks_mask;
 	uint64_t all_tracks_mask;
 	uint64_t cur_track_mask;
-	uint64_t initial_time;
+	uint64_t initial_time = 0;
 	mkv_index_t prev_index;
 	mkv_index_t index;
 	vod_status_t rc;
@@ -1016,7 +1016,6 @@ mkv_get_read_frames_request(
 
 	read_req->read_offset = ULLONG_MAX;
 	read_req->flags = 0;
-	initial_time = 0;
 
 	prev_index.cluster_pos = ULLONG_MAX;
 	seen_tracks_mask = 0;

--- a/vod/mkv/mkv_format.c
+++ b/vod/mkv/mkv_format.c
@@ -1297,18 +1297,14 @@ mkv_update_frame_timestamps(mkv_frame_parse_track_context_t* context)
 		for (; cur_frame < last_frame; cur_frame++)
 		{
 			pts_delay = cur_frame->unsorted_timecode - cur_frame->timecode;
-
+			cur_frame->unsorted_frame->pts_delay = pts_delay;
 			if (pts_delay < context->min_pts_delay)
 			{
 				context->min_pts_delay = pts_delay;
 			}
 
-			cur_frame->unsorted_frame->pts_delay = pts_delay;
-
 			duration = cur_frame[1].timecode - cur_frame[0].timecode;
-
 			mkv_update_laces_duration(&cur_frame->frame, duration);
-
 			context->total_frames_duration += duration;
 		}
 	}
@@ -1341,12 +1337,12 @@ mkv_estimate_next_frame_timecode(
 	uint64_t max_timecode;
 	uint64_t result;
 
-	cur_frame = context->gop_frames.elts;
-	last_frame = cur_frame + (context->gop_frames.nelts - 1);
-
 	// get the number of pending laces + max timecode
 	laces = 0;
 	max_timecode = 0;
+
+	cur_frame = context->gop_frames.elts;
+	last_frame = cur_frame + (context->gop_frames.nelts - 1);
 	for (; cur_frame < last_frame; cur_frame++)
 	{
 		laces += cur_frame->frame.laces;

--- a/vod/mkv/mkv_format.c
+++ b/vod/mkv/mkv_format.c
@@ -1016,6 +1016,7 @@ mkv_get_read_frames_request(
 
 	read_req->read_offset = ULLONG_MAX;
 	read_req->flags = 0;
+	initial_time = 0;
 
 	prev_index.cluster_pos = ULLONG_MAX;
 	seen_tracks_mask = 0;

--- a/vod/mp4/mp4_init_segment.c
+++ b/vod/mp4/mp4_init_segment.c
@@ -489,12 +489,23 @@ mp4_init_segment_write_avcc_atom(u_char* p, media_track_t* track)
 }
 
 static u_char*
+mp4_init_segment_write_hvcc_atom(u_char* p, media_track_t* track)
+{
+	size_t atom_size = ATOM_HEADER_SIZE + track->media_info.extra_data.len;
+
+	write_atom_header(p, atom_size, 'h', 'v', 'c', 'C');
+	p = vod_copy(p, track->media_info.extra_data.data, track->media_info.extra_data.len);
+	return p;
+}
+
+static u_char*
 mp4_init_segment_write_stsd_video_entry(u_char* p, media_track_t* track)
 {
 	size_t atom_size = ATOM_HEADER_SIZE + sizeof(sample_entry_t) + sizeof(stsd_video_t) +
 		ATOM_HEADER_SIZE + track->media_info.extra_data.len;
 
-	write_atom_header(p, atom_size, 'a', 'v', 'c', '1');
+	write_be32(p, atom_size);
+	p = ngx_copy(p, &track->media_info.format, sizeof(track->media_info.format));
 
 	// sample_entry_t
 	write_be32(p, 0);		// reserved
@@ -518,15 +529,24 @@ mp4_init_segment_write_stsd_video_entry(u_char* p, media_track_t* track)
 	write_be16(p, 0x18);	// depth
 	write_be16(p, 0xffff);	// pre defined
 
-	p = mp4_init_segment_write_avcc_atom(p, track);
+	switch (track->media_info.codec_id)
+	{
+	case VOD_CODEC_ID_AVC:
+		p = mp4_init_segment_write_avcc_atom(p, track);
+		break;
+
+	case VOD_CODEC_ID_HEVC:
+		p = mp4_init_segment_write_hvcc_atom(p, track);
+		break;
+	}
 
 	return p;
 }
 
 static u_char*
-mp4_init_segment_write_esds_atom(u_char* p, media_track_t* track)
+mp4_init_segment_write_esds_atom(u_char* p, media_info_t* media_info)
 {
-	size_t extra_data_len = track->media_info.extra_data.len;
+	size_t extra_data_len = media_info->extra_data.len;
 	size_t atom_size = mp4_esds_atom_size(extra_data_len);
 
 	write_atom_header(p, atom_size, 'e', 's', 'd', 's');
@@ -541,15 +561,15 @@ mp4_init_segment_write_esds_atom(u_char* p, media_track_t* track)
 	*p++ = MP4DecConfigDescrTag;				// tag
 	*p++ = sizeof(config_descr_t) +				// len
 		sizeof(descr_header_t) + extra_data_len;
-	*p++ = track->media_info.u.audio.object_type_id;
+	*p++ = media_info->u.audio.object_type_id;
 	*p++ = 0x15;								// stream type
 	write_be24(p, 0);							// buffer size
-	write_be32(p, track->media_info.bitrate);	// max bitrate
-	write_be32(p, track->media_info.bitrate);	// avg bitrate
+	write_be32(p, media_info->bitrate);	// max bitrate
+	write_be32(p, media_info->bitrate);	// avg bitrate
 
 	*p++ = MP4DecSpecificDescrTag;				// tag
 	*p++ = extra_data_len;						// len
-	p = vod_copy(p, track->media_info.extra_data.data, extra_data_len);
+	p = vod_copy(p, media_info->extra_data.data, extra_data_len);
 
 	*p++ = MP4SLDescrTag;						// tag
 	*p++ = 1;									// len
@@ -558,13 +578,34 @@ mp4_init_segment_write_esds_atom(u_char* p, media_track_t* track)
 	return p;
 }
 
-static u_char*
-mp4_init_segment_write_stsd_audio_entry(u_char* p, media_track_t* track)
+static vod_inline size_t
+mp4_init_segment_get_stsd_audio_entry_size(media_info_t* media_info)
 {
-	size_t atom_size = ATOM_HEADER_SIZE + sizeof(sample_entry_t) + sizeof(stsd_audio_t) +
-		mp4_esds_atom_size(track->media_info.extra_data.len);
+	size_t size;
 
-	write_atom_header(p, atom_size, 'm', 'p', '4', 'a');
+	size = ATOM_HEADER_SIZE + sizeof(sample_entry_t) + sizeof(stsd_audio_t);
+
+	if (media_info->format == FORMAT_MP4A)
+	{
+		size += mp4_esds_atom_size(media_info->extra_data.len);
+	}
+	else
+	{
+		size += ATOM_HEADER_SIZE + media_info->extra_data.len;
+	}
+
+	return size;
+}
+
+static u_char*
+mp4_init_segment_write_stsd_audio_entry(u_char* p, media_info_t* media_info)
+{
+	size_t atom_size;
+
+	atom_size = mp4_init_segment_get_stsd_audio_entry_size(media_info);
+
+	write_be32(p, atom_size);
+	p = ngx_copy(p, &media_info->format, sizeof(media_info->format));
 
 	// sample_entry_t
 	write_be32(p, 0);		// reserved
@@ -574,14 +615,38 @@ mp4_init_segment_write_stsd_audio_entry(u_char* p, media_track_t* track)
 	// stsd_audio_t
 	write_be32(p, 0);		// reserved
 	write_be32(p, 0);		// reserved
-	write_be16(p, track->media_info.u.audio.channels);
-	write_be16(p, track->media_info.u.audio.bits_per_sample);
+	write_be16(p, media_info->u.audio.channels);
+	write_be16(p, media_info->u.audio.bits_per_sample);
 	write_be16(p, 0);		// pre defined
 	write_be16(p, 0);		// reserved
-	write_be16(p, track->media_info.u.audio.sample_rate);
+	write_be16(p, media_info->u.audio.sample_rate);
 	write_be16(p, 0);
 
-	p = mp4_init_segment_write_esds_atom(p, track);
+	if (media_info->format == FORMAT_MP4A)
+	{
+		p = mp4_init_segment_write_esds_atom(p, media_info);
+	}
+	else
+	{
+		atom_size = ATOM_HEADER_SIZE + media_info->extra_data.len;
+
+		switch (media_info->codec_id)
+		{
+		case VOD_CODEC_ID_AC3:
+			write_atom_header(p, atom_size, 'd', 'a', 'c', '3');
+			break;
+
+		case VOD_CODEC_ID_EAC3:
+			write_atom_header(p, atom_size, 'd', 'e', 'c', '3');
+			break;
+
+		case VOD_CODEC_ID_OPUS:
+			write_atom_header(p, atom_size, 'd', 'O', 'p', 's');
+			break;
+		}
+
+		p = vod_copy(p, media_info->extra_data.data, media_info->extra_data.len);
+	}
 
 	return p;
 }
@@ -594,13 +659,12 @@ mp4_init_segment_get_stsd_atom_size(media_track_t* track)
 	switch (track->media_info.media_type)
 	{
 	case MEDIA_TYPE_VIDEO:
-		atom_size += ATOM_HEADER_SIZE + sizeof(sample_entry_t) + sizeof(stsd_video_t)+
+		atom_size += ATOM_HEADER_SIZE + sizeof(sample_entry_t) + sizeof(stsd_video_t) +
 			ATOM_HEADER_SIZE + track->media_info.extra_data.len;
 		break;
 
 	case MEDIA_TYPE_AUDIO:
-		atom_size += ATOM_HEADER_SIZE + sizeof(sample_entry_t) + sizeof(stsd_audio_t)+
-			mp4_esds_atom_size(track->media_info.extra_data.len);
+		atom_size += mp4_init_segment_get_stsd_audio_entry_size(&track->media_info);
 		break;
 	}
 
@@ -620,7 +684,7 @@ mp4_init_segment_write_stsd_atom(u_char* p, size_t atom_size, media_track_t* tra
 		break;
 
 	case MEDIA_TYPE_AUDIO:
-		p = mp4_init_segment_write_stsd_audio_entry(p, track);
+		p = mp4_init_segment_write_stsd_audio_entry(p, &track->media_info);
 		break;
 	}
 	return p;


### PR DESCRIPTION
when reading frames, need to read a bit extra in order to have the headers of the frame following the last frame of the segment (in order to calcuation the duration of the last frame)
in addition to reading a few bytes extra, need to ignore overflow when parsing the cluster/simple-block elements of the next-segment frame, since usually this frame is not read in full.