### PR TITLE
hls: add vod_hls_encryption_output_iv directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1714,6 +1714,13 @@ The parameter value can contain variables.
 When enabled, the module will shift back the dts timestamps by the pts delay of the initial frame.
 This can help keep the pts timestamps aligned across multiple renditions.
 
+#### vod_hls_encryption_output_iv
+* **syntax**: `vod_hls_encryption_output_iv on/off`
+* **default**: `off`
+* **context**: `http`, `server`, `location`
+
+When enabled, the module outputs the `IV` attribute in returned `#EXT-X-KEY` tags. This currently applies when `vod_drm_enabled` is enabled and `vod_hls_encryption_method` is set to `aes-128`, with `vod_hls_encryption_key_format` set to `none` or `identity`.
+
 ### Configuration directives - MSS
 
 #### vod_mss_manifest_file_name_prefix

--- a/README.md
+++ b/README.md
@@ -1719,7 +1719,7 @@ This can help keep the pts timestamps aligned across multiple renditions.
 * **default**: `off`
 * **context**: `http`, `server`, `location`
 
-When enabled, the module outputs the `IV` attribute in returned `#EXT-X-KEY` tags. This currently applies when `vod_drm_enabled` is enabled and `vod_hls_encryption_method` is set to `aes-128`, with `vod_hls_encryption_key_format` set to `none` or `identity`.
+When enabled, the module outputs the `IV` attribute in returned `#EXT-X-KEY` tags.
 
 ### Configuration directives - MSS
 

--- a/ngx_http_vod_hls.c
+++ b/ngx_http_vod_hls.c
@@ -171,7 +171,7 @@ ngx_http_vod_hls_init_encryption_params(
 	}
 
 	encryption_params->iv = encryption_params->iv_buf;
-	encryption_params->return_iv = FALSE;
+	encryption_params->return_iv = conf->hls.output_iv;
 
 	sequence = &submodule_context->media_set.sequences[0];
 
@@ -183,16 +183,6 @@ ngx_http_vod_hls_init_encryption_params(
 		if (drm_info->iv_set)
 		{
 			encryption_params->iv = drm_info->iv;
-
-			// check encryption key method must be aes-128, encryption key format can be "identity" or empty and output_iv set to true then return iv
-			// https://datatracker.ietf.org/doc/html/rfc8216#section-5.2
-			if (conf->hls.encryption_method == HLS_ENC_AES_128 && 
-			(conf->hls.m3u8_config.encryption_key_format.len == 0 || ngx_strncmp(conf->hls.m3u8_config.encryption_key_format.data, "identity", conf->hls.m3u8_config.encryption_key_format.len) == 0) && 
-			conf->hls.output_iv)
-			{
-				encryption_params->return_iv = TRUE;
-			}
-			
 			return NGX_OK;
 		}
 	}

--- a/ngx_http_vod_hls.c
+++ b/ngx_http_vod_hls.c
@@ -183,6 +183,16 @@ ngx_http_vod_hls_init_encryption_params(
 		if (drm_info->iv_set)
 		{
 			encryption_params->iv = drm_info->iv;
+
+			// check encryption key method must be aes-128, encryption key format can be "identity" or empty and output_iv set to true then return iv
+			// https://datatracker.ietf.org/doc/html/rfc8216#section-5.2
+			if (conf->hls.encryption_method == HLS_ENC_AES_128 && 
+			(conf->hls.m3u8_config.encryption_key_format.len == 0 || ngx_strncmp(conf->hls.m3u8_config.encryption_key_format.data, "identity", conf->hls.m3u8_config.encryption_key_format.len) == 0) && 
+			conf->hls.output_iv)
+			{
+				encryption_params->return_iv = TRUE;
+			}
+			
 			return NGX_OK;
 		}
 	}
@@ -1116,6 +1126,7 @@ ngx_http_vod_hls_create_loc_conf(
 	conf->align_pts = NGX_CONF_UNSET;
 	conf->output_id3_timestamps = NGX_CONF_UNSET;
 	conf->encryption_method = NGX_CONF_UNSET_UINT;
+	conf->output_iv = NGX_CONF_UNSET;
 	conf->m3u8_config.output_iframes_playlist = NGX_CONF_UNSET;
 	conf->m3u8_config.force_unmuxed_segments = NGX_CONF_UNSET;
 	conf->m3u8_config.container_format = NGX_CONF_UNSET_UINT;
@@ -1131,6 +1142,7 @@ ngx_http_vod_hls_merge_loc_conf(
 	ngx_conf_merge_value(conf->absolute_master_urls, prev->absolute_master_urls, 1);
 	ngx_conf_merge_value(conf->absolute_index_urls, prev->absolute_index_urls, 1);
 	ngx_conf_merge_value(conf->absolute_iframe_urls, prev->absolute_iframe_urls, 0);
+	ngx_conf_merge_value(conf->output_iv, prev->output_iv, 0);
 	ngx_conf_merge_value(conf->m3u8_config.output_iframes_playlist, prev->m3u8_config.output_iframes_playlist, 1);
 
 	ngx_conf_merge_str_value(conf->master_file_name_prefix, prev->master_file_name_prefix, "master");

--- a/ngx_http_vod_hls_commands.h
+++ b/ngx_http_vod_hls_commands.h
@@ -35,6 +35,13 @@
 	NGX_HTTP_LOC_CONF_OFFSET,
 	BASE_OFFSET + offsetof(ngx_http_vod_hls_loc_conf_t, m3u8_config.encryption_key_format_versions),
 	NULL },	
+
+	{ ngx_string("vod_hls_encryption_output_iv"),
+	NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+	ngx_conf_set_flag_slot,
+	NGX_HTTP_LOC_CONF_OFFSET,
+	BASE_OFFSET + offsetof(ngx_http_vod_hls_loc_conf_t, output_iv),
+	NULL },
 #endif // NGX_HAVE_OPENSSL_EVP
 
 	{ ngx_string("vod_hls_container_format"),

--- a/ngx_http_vod_hls_conf.h
+++ b/ngx_http_vod_hls_conf.h
@@ -19,6 +19,7 @@ typedef struct
 	ngx_http_complex_value_t* id3_data;
 	vod_uint_t encryption_method;
 	ngx_http_complex_value_t* encryption_key_uri;
+	bool_t output_iv;
 
 	// derived fields
 	m3u8_config_t m3u8_config;


### PR DESCRIPTION
According to issue #1507 , add the `vod_hls_encryption_output_iv` directive to output `IV` attributes to the `#EXT-X-KEY` tag in the m3u8 file. 

~~This option will apply when `vod_drm_enabled` is enabled, and `vod_hls_encryption_method` is set to `aes-128`, with `vod_hls_encryption_key_format` set to `none` or `identity`.~~