### PR TITLE
feat: do not output cues that started before the segment

### DIFF
--- a/vod/subtitle/webvtt_builder.c
+++ b/vod/subtitle/webvtt_builder.c
@@ -36,6 +36,7 @@ webvtt_builder_build(
 	input_frame_t* last_frame;
 	uint64_t start_time;
 	uint64_t base_time;
+    uint64_t segment_start_time = media_set->segment_start_time;
 	uint32_t id_size;
 	size_t result_size;
 	u_char* end;
@@ -115,21 +116,25 @@ webvtt_builder_build(
 				last_frame = part->last_frame;
 			}
 
-			src = (u_char*)(uintptr_t)cur_frame->offset;
+			if (start_time >= segment_start_time) {
+				src = (u_char * )(uintptr_t)
+				cur_frame->offset;
 
-			// cue identifier
-			id_size = cur_frame->key_frame;
-			p = vod_copy(p, src, id_size);
-			src += id_size;
+				// cue identifier
+				id_size = cur_frame->key_frame;
+				p = vod_copy(p, src, id_size);
+				src += id_size;
 
-			// cue timings
-			p = webvtt_builder_write_timestamp(p, start_time);
-			p = vod_copy(p, WEBVTT_TIMESTAMP_DELIM, sizeof(WEBVTT_TIMESTAMP_DELIM) - 1);
-			p = webvtt_builder_write_timestamp(p, start_time + cur_frame->pts_delay);
+				// cue timings
+				p = webvtt_builder_write_timestamp(p, start_time);
+				p = vod_copy(p, WEBVTT_TIMESTAMP_DELIM, sizeof(WEBVTT_TIMESTAMP_DELIM) - 1);
+				p = webvtt_builder_write_timestamp(p, start_time + cur_frame->pts_delay);
+
+				// cue settings list + cue payload
+				p = vod_copy(p, src, cur_frame->size - id_size);
+			}
+
 			start_time += cur_frame->duration;
-
-			// cue settings list + cue payload
-			p = vod_copy(p, src, cur_frame->size - id_size);
 		}
 	}
 


### PR DESCRIPTION
Chromecast shakaplayer does not de-duplicate cues in HLS. 

This fixes it by only outputing cues that start during the segment.

From my understanding (and some testing), the subtitles will not disappear early on segment change in normal playback if they are not duplicated in all segments. The only ill effect I can think of is that the cue will not appear on seek in some cases. But this is not a common use case, so a much less visible impact than duplicated segments.

For example with 8s segments, segment 2 will be from 00:08:00  to 00:16:00

### Before:
**s-1-f7.vtt**
```
WEBVTT

1
00:00:00.120 --> 00:00:4.120
Dies ist ein Text auf Türkisch

2
00:00:07.320 --> 00:00:09.920
* Roter Hintergrund *
```
**s-2-f7.vtt**
```
WEBVTT

2
00:00:07.320 --> 00:00:09.920
* Roter Hintergrund *

3
00:00:10.120 --> 00:00:12.120
Dies ist ein Text auf Türkisch
```
### After:
**s-1-f7.vtt**
```
WEBVTT

1
00:00:00.120 --> 00:00:4.120
Dies ist ein Text auf Türkisch

2
00:00:07.320 --> 00:00:09.920
* Roter Hintergrund *
```
**s-2-f7.vtt**
```
WEBVTT

3
00:00:10.120 --> 00:00:12.120
Dies ist ein Text auf Türkisch
```