### PR TITLE
Use MP4 average frame duration for M3U8 playlist FRAME-RATE calculation

### DIFF
--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -2820,6 +2820,18 @@ ngx_http_vod_update_track_timescale(
 			}
 		}
 
+		if (track->media_info.avg_frame_duration != 0)
+		{
+			track->media_info.avg_frame_duration =
+				rescale_time(track->media_info.avg_frame_duration, cur_timescale, new_timescale);
+			if (track->media_info.avg_frame_duration == 0)
+			{
+				ngx_log_error(NGX_LOG_WARN, ctx->submodule_context.request_context.log, 0,
+					"ngx_http_vod_update_track_timescale: avg frame duration is zero following rescale");
+				track->media_info.avg_frame_duration = 1;
+			}
+		}
+
 		track->media_info.u.video.initial_pts_delay =
 			rescale_time(track->media_info.u.video.initial_pts_delay, cur_timescale, new_timescale);
 	}

--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -1145,8 +1145,8 @@ m3u8_builder_write_variants(
 				bitrate,
 				(uint32_t)video->u.video.width,
 				(uint32_t)video->u.video.height,
-				(uint32_t)(video->timescale / video->min_frame_duration),
-				(uint32_t)((((uint64_t)video->timescale * 1000) / video->min_frame_duration) % 1000),
+				(uint32_t)(video->timescale / video->avg_frame_duration),
+				(uint32_t)((((uint64_t)video->timescale * 1000) / video->avg_frame_duration) % 1000),
 				&video->codec_name);
 			if (audio != NULL)
 			{

--- a/vod/media_format.h
+++ b/vod/media_format.h
@@ -244,6 +244,7 @@ typedef struct media_info_s {
 	uint32_t bitrate;
 	uint32_t avg_bitrate;
 	uint32_t min_frame_duration;	// valid only for video		XXXXX move to video_media_info_t
+	uint32_t avg_frame_duration;
 	uint32_t codec_id;
 	vod_str_t codec_name;
 	vod_str_t extra_data;

--- a/vod/mp4/mp4_parser.c
+++ b/vod/mp4/mp4_parser.c
@@ -626,6 +626,9 @@ mp4_parser_parse_stts_atom_frame_duration_only(atom_info_t* atom_info, frames_pa
 	const stts_entry_t* cur_entry;
 	uint32_t entries;
 	uint32_t cur_duration;
+	uint32_t cur_count;
+	uint64_t sum_duration = 0;
+	uint32_t frames_count = 0;
 	vod_status_t rc;
 
 	rc = mp4_parser_validate_stts_data(context->request_context, atom_info, &entries);
@@ -645,10 +648,14 @@ mp4_parser_parse_stts_atom_frame_duration_only(atom_info_t* atom_info, frames_pa
 	for (; cur_entry < last_entry; cur_entry++)
 	{
 		cur_duration = parse_be32(cur_entry->duration);
+		cur_count = parse_be32(cur_entry->count);
 		if (cur_duration == 0)
 		{
 			continue;
 		}
+
+		sum_duration += cur_duration * cur_count;
+		frames_count += cur_count;
 
 		if (cur_duration != 0 && (media_info->min_frame_duration == 0 || cur_duration < media_info->min_frame_duration))
 		{
@@ -660,6 +667,22 @@ mp4_parser_parse_stts_atom_frame_duration_only(atom_info_t* atom_info, frames_pa
 	{
 		vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
 			"mp4_parser_parse_stts_atom_frame_duration_only: min frame duration is zero");
+		return VOD_BAD_DATA;
+	}
+
+	if (frames_count == 0)
+	{
+		vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
+			"mp4_parser_parse_stts_atom_frame_duration_only: frames count is zero");
+		return VOD_BAD_DATA;
+	}
+
+	media_info->avg_frame_duration = (uint32_t)(sum_duration / frames_count);
+
+	if (media_info->avg_frame_duration == 0)
+	{
+		vod_log_error(VOD_LOG_ERR, context->request_context->log, 0,
+			"mp4_parser_parse_stts_atom_frame_duration_only: avg frame duration is zero");
 		return VOD_BAD_DATA;
 	}
 


### PR DESCRIPTION
Some of MP4 videos have frames daration less than average frame duration, which leads to big FRAME-RATE values in M3U8 playlists. 

This pull request offers to use average frame duation for FRAME-RATE into M3U8 playlists for MP4

EXAMPLE:

Current logic:
`
#EXTM3U
#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1662071,RESOLUTION=480x854,FRAME-RATE=573.248,CODECS="avc1.64001f,mp4a.40.2",VIDEO-RANGE=SDR
./index-f1-v1-a1.m3u8
#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=843389,RESOLUTION=360x640,FRAME-RATE=573.248,CODECS="avc1.64001e,mp4a.40.2",VIDEO-RANGE=SDR
./index-f2-v1-a1.m3u8
`

New logic:
`
#EXTM3U
#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1662071,RESOLUTION=480x854,FRAME-RATE=30.060,CODECS="avc1.64001f,mp4a.40.2",VIDEO-RANGE=SDR
./index-f1-v1-a1.m3u8
#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=843389,RESOLUTION=360x640,FRAME-RATE=30.060,CODECS="avc1.64001e,mp4a.40.2",VIDEO-RANGE=SDR
./index-f2-v1-a1.m3u8
`