### PR TITLE
config: make clock_gettime() check work

### DIFF
--- a/config
+++ b/config
@@ -127,10 +127,10 @@ ngx_feature_test="iconv_open(NULL, NULL);"
 ngx_feature="clock_gettime()"
 ngx_feature_name="NGX_HAVE_CLOCK_GETTIME"
 ngx_feature_run=no
-ngx_feature_incs="#include <sched.h>"
+ngx_feature_incs="#include <time.h>"
 ngx_feature_path=
 ngx_feature_libs=
-ngx_feature_test="clock_gettime()"
+ngx_feature_test="clockid_t c; clock_gettime(c, NULL)"
 . auto/feature
 
 if [ $ngx_found != yes ]; then


### PR DESCRIPTION
The clock_gettime() function is provided by time.h, but the check included sched.h. Additionally, the function expects two arguments, but none were given.

This commit fixes both issues, making the check actually work.

Fixes #1566.