### PR TITLE
support arbitrary language selection

### DIFF
--- a/ngx_http_vod_module.c
+++ b/ngx_http_vod_module.c
@@ -1554,7 +1554,7 @@ ngx_http_vod_init_parse_params_metadata(
 		vod_track_mask_and_bits(tracks_mask[media_type], cur_source->tracks_mask[media_type], request_tracks_mask[media_type]);
 	}
 	parse_params->required_tracks_mask = tracks_mask;
-	parse_params->langs_mask = ctx->submodule_context.request_params.langs_mask;
+	parse_params->langs = ctx->submodule_context.request_params.langs;
 	parse_params->source = cur_source;
 }
 
@@ -3576,8 +3576,7 @@ ngx_http_vod_run_generators(ngx_http_vod_ctx_t *ctx)
 			continue;
 		}
 
-		if (parse_params.langs_mask != NULL &&
-			!vod_is_bit_set(parse_params.langs_mask, cur_source->sequence->tags.language))
+		if (!media_format_lang_exists(parse_params.langs, &cur_source->sequence->tags.lang_str))
 		{
 			ngx_memzero(&cur_source->track_array, sizeof(cur_source->track_array));
 			continue;

--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -218,6 +218,8 @@ ngx_http_vod_parse_uri_file_name(
 	sequence_tracks_mask_t* sequence_tracks_mask;
 	ngx_str_t* cur_sequence_id;
 	ngx_str_t* last_sequence_id;
+	ngx_str_t* cur_lang;
+	ngx_str_t* last_lang;
 	track_mask_t default_tracks_mask;
 	track_mask_t* tracks_mask;
 	uint32_t segment_index_shift;
@@ -480,35 +482,38 @@ ngx_http_vod_parse_uri_file_name(
 	// languages
 	if (*start_pos == 'l')
 	{
-		result->langs_mask = ngx_pcalloc(r->pool, LANG_MASK_SIZE * sizeof(result->langs_mask[0]));
-		if (result->langs_mask == NULL)
+		result->langs = ngx_pcalloc(r->pool, MAX_LANGUAGE_COUNT * sizeof(result->langs[0]));
+		if (result->langs == NULL)
 		{
 			ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
 				"ngx_http_vod_parse_uri_file_name: ngx_palloc failed");
 			return ngx_http_vod_status_to_ngx_error(r, VOD_ALLOC_FAILED);
 		}
 
+		cur_lang = result->langs;
+		last_lang = cur_lang + MAX_LANGUAGE_COUNT;
+
 		for (;;)
 		{
 			start_pos++;		// skip the l
-			if (start_pos + LANG_ISO639_3_LEN > end_pos)
+
+			if (cur_lang >= last_lang)
 			{
 				ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-					"ngx_http_vod_parse_uri_file_name: language specifier length must be 3 characters");
+					"ngx_http_vod_parse_uri_file_name: the number of language codes exceeds the limit");
 				return ngx_http_vod_status_to_ngx_error(r, VOD_BAD_REQUEST);
 			}
 
-			lang_id = lang_parse_iso639_3_code(iso639_3_str_to_int(start_pos));
-			if (lang_id == 0)
+			cur_lang->data = start_pos;
+
+			while (start_pos < end_pos && *start_pos != '-')
 			{
-				ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-					"ngx_http_vod_parse_uri_file_name: failed to parse language specifier %*s", (size_t)3, start_pos);
-				return ngx_http_vod_status_to_ngx_error(r, VOD_BAD_REQUEST);
+				start_pos++;
 			}
 
-			vod_set_bit(result->langs_mask, lang_id);
+			cur_lang->len = start_pos - cur_lang->data;
 
-			start_pos += LANG_ISO639_3_LEN;
+			cur_lang++;
 
 			skip_dash(start_pos, end_pos);
 

--- a/ngx_http_vod_request_parse.c
+++ b/ngx_http_vod_request_parse.c
@@ -229,7 +229,6 @@ ngx_http_vod_parse_uri_file_name(
 	uint32_t pts_delay;
 	uint32_t version;
 	bool_t tracks_mask_updated;
-	language_id_t lang_id;
 
 	if (flags & PARSE_FILE_NAME_MULTI_STREAMS_PER_TYPE)
 	{

--- a/vod/language_code.h
+++ b/vod/language_code.h
@@ -6,7 +6,6 @@
 
 // constants
 #define LANG_ISO639_3_LEN (3)
-#define LANG_MASK_SIZE vod_array_length_for_bits(VOD_LANG_COUNT)
 
 // macros
 #define iso639_3_str_to_int(x) \

--- a/vod/media_format.c
+++ b/vod/media_format.c
@@ -3,6 +3,30 @@
 #include "avc_parser.h"
 #include "hevc_parser.h"
 
+bool_t
+media_format_lang_exists(vod_str_t* langs, vod_str_t* lang)
+{
+	vod_str_t* cur;
+	vod_str_t* last;
+
+	if (langs == NULL)
+	{
+		return TRUE;
+	}
+
+	last = langs + MAX_LANGUAGE_COUNT;
+	for (cur = langs; cur < last && cur->len != 0; cur++)
+	{
+		if (lang->len == cur->len &&
+			vod_strncasecmp(lang->data, cur->data, cur->len) == 0)
+		{
+			return TRUE;
+		}
+	}
+
+	return FALSE;
+}
+
 vod_status_t
 media_format_finalize_track(
 	request_context_t* request_context, 

--- a/vod/media_format.c
+++ b/vod/media_format.c
@@ -185,5 +185,12 @@ media_format_finalize_track(
 		media_info->extra_data.len = 0;
 	}
 
+	// output short (ISO-639-1) language codes when possible
+	if (media_info->tags.language != 0 && media_info->tags.lang_str.len == LANG_ISO639_3_LEN)
+	{
+		media_info->tags.lang_str.data = (u_char *)lang_get_rfc_5646_name(media_info->tags.language);
+		media_info->tags.lang_str.len = ngx_strlen(media_info->tags.lang_str.data);
+	}
+
 	return VOD_OK;
 }

--- a/vod/media_format.h
+++ b/vod/media_format.h
@@ -35,6 +35,7 @@
 #define MAX_DURATION_SEC (1000000)
 #define MAX_CLIP_DURATION (90000000)		// 25h
 #define MAX_SEQUENCE_DURATION (864000000)		// 10 days
+#define MAX_LANGUAGE_COUNT (4)
 
 // read flags
 #define MEDIA_READ_FLAG_REALLOC_BUFFER	(0x1)
@@ -180,7 +181,7 @@ typedef struct {
 
 typedef struct {
 	track_mask_t* required_tracks_mask;
-	uint64_t* langs_mask;
+	ngx_str_t* langs;
 	uint32_t clip_from;
 	uint32_t clip_to;
 	media_range_t* range;
@@ -400,6 +401,8 @@ typedef struct {
 } media_format_t;
 
 // functions
+bool_t media_format_lang_exists(vod_str_t* langs, vod_str_t* lang);
+
 vod_status_t media_format_finalize_track(
 	request_context_t* request_context,
 	int parse_type,

--- a/vod/media_set.h
+++ b/vod/media_set.h
@@ -181,7 +181,7 @@ typedef struct {
 	track_mask_t tracks_mask[MEDIA_TYPE_COUNT];
 	sequence_tracks_mask_t* sequence_tracks_mask;
 	sequence_tracks_mask_t* sequence_tracks_mask_end;
-	uint64_t* langs_mask;			// [LANG_MASK_SIZE]
+	vod_str_t* langs;
 	uint32_t version;
 	uint32_t width;
 	uint32_t height;

--- a/vod/media_set_parser.c
+++ b/vod/media_set_parser.c
@@ -1013,11 +1013,6 @@ media_set_parse_sequences(
 			if (cur_output->tags.lang_str.len >= LANG_ISO639_3_LEN)
 			{
 				cur_output->tags.language = lang_parse_iso639_3_code(iso639_3_str_to_int(cur_output->tags.lang_str.data));
-				if (cur_output->tags.language != 0)
-				{
-					cur_output->tags.lang_str.data = (u_char *)lang_get_rfc_5646_name(cur_output->tags.language);
-					cur_output->tags.lang_str.len = ngx_strlen(cur_output->tags.lang_str.data);
-				}
 			}
 
 			if (cur_output->tags.label.len == 0)

--- a/vod/mkv/mkv_format.c
+++ b/vod/mkv/mkv_format.c
@@ -867,9 +867,8 @@ mkv_metadata_parse(
 		}
 
 		// filter by language
-		if (parse_params->langs_mask != NULL &&
-			media_type == MEDIA_TYPE_AUDIO &&
-			!vod_is_bit_set(parse_params->langs_mask, lang_id))
+		if (media_type == MEDIA_TYPE_AUDIO &&
+			!media_format_lang_exists(parse_params->langs, &track.language))
 		{
 			continue;
 		}

--- a/vod/mp4/mp4_parser.c
+++ b/vod/mp4/mp4_parser.c
@@ -2889,9 +2889,8 @@ mp4_parser_process_moov_atom_callback(void* ctx, atom_info_t* atom_info)
 	}
 
 	// filter by language
-	if (context->parse_params.langs_mask != NULL &&
-		metadata_parse_context.media_info.media_type == MEDIA_TYPE_AUDIO &&
-		!vod_is_bit_set(context->parse_params.langs_mask, metadata_parse_context.media_info.tags.language))
+	if (metadata_parse_context.media_info.media_type == MEDIA_TYPE_AUDIO &&
+		!media_format_lang_exists(context->parse_params.langs, &metadata_parse_context.media_info.tags.lang_str))
 	{
 		return VOD_OK;
 	}

--- a/vod/subtitle/subtitle_format.c
+++ b/vod/subtitle/subtitle_format.c
@@ -97,8 +97,7 @@ subtitle_parse(
 	}
 
 	// filter by language
-	if (parse_params->langs_mask != NULL &&
-		!vod_is_bit_set(parse_params->langs_mask, tags.language))
+	if (!media_format_lang_exists(parse_params->langs, &tags.lang_str))
 	{
 		metadata->base.tracks.nelts = 0;
 		return VOD_OK;


### PR DESCRIPTION
currently, language filtering (-l param) works only for pre-defined languages.
change the code to use lang_str string comparison instead, in order to support arbitrary languages (incl. for example, language codes with extentions like zh_cn)