### PR TITLE
Change thumb scaler pixel format to AV_PIX_FMT_YUVJ420P

### DIFF
--- a/vod/thumb/thumb_grabber.c
+++ b/vod/thumb/thumb_grabber.c
@@ -594,7 +594,7 @@ thumb_grabber_resize_frame(thumb_grabber_state_t* state)
 
 	output_frame->width = state->encoder->width;
 	output_frame->height = state->encoder->height;
-	output_frame->format = AV_PIX_FMT_YUV420P;
+	output_frame->format = AV_PIX_FMT_YUVJ420P;
 
 	sws_ctx = sws_getContext(
 		input_frame->width, input_frame->height, input_frame->format,


### PR DESCRIPTION
Fixes https://github.com/kaltura/nginx-vod-module/issues/1537

Problem in short: swscaler generates limited-range output, but the jpeg encoder needs full-range input.
Changing swscaler's output pixel format to AV_PIX_FMT_YUVJ420P seems to fix the issue.