### PR TITLE
Ensure that each audio group has a default

### DIFF
--- a/vod/hls/m3u8_builder.c
+++ b/vod/hls/m3u8_builder.c
@@ -954,7 +954,8 @@ m3u8_builder_ext_x_media_tags_write(
 	adaptation_set_t* adaptation_set;
 	media_track_t* tracks[MEDIA_TYPE_COUNT];
 	vod_str_t* label;
-	uint32_t group_index;
+	uint32_t group_index = 0;
+	uint32_t last_group_index = UINT_MAX;
 	bool_t is_default;
 	char* group_id;
 	char* type;
@@ -991,10 +992,6 @@ m3u8_builder_ext_x_media_tags_write(
 		{
 			group_index = tracks[media_type]->media_info.codec_id - VOD_CODEC_ID_AUDIO;
 		}
-		else
-		{
-			group_index = 0;
-		}
 
 		label = &tracks[media_type]->media_info.tags.label;
 		if (label->len == 0)
@@ -1017,7 +1014,8 @@ m3u8_builder_ext_x_media_tags_write(
 		is_default = tracks[media_type]->media_info.tags.is_default;
 		if (is_default < 0)
 		{
-			is_default = adaptation_set == first_adaptation_set;
+			is_default = adaptation_set == first_adaptation_set || group_index != last_group_index;
+			last_group_index = group_index;
 		}
 
 		if (is_default)


### PR DESCRIPTION
As per [documentation](https://github.com/kaltura/nginx-vod-module/blob/26f06877b0f2a2336e59cda93a3de18d7b23a3e2/README.md#sequence):

> `default` - If not specified, the first EXT-X-MEDIA tag in **each group** returns DEFAULT=YES.

#### Actual

The first EXT-X-MEDIA tag in **each type** returns DEFAULT=YES.

> Assuming that #1561 has been applied.

#### Expected

The first EXT-X-MEDIA tag in **each group** returns DEFAULT=YES.