### PR TITLE
Stop accessing deprecated _xmlParserCtxt::recovery attribute

### DIFF
--- a/vod/subtitle/dfxp_format.c
+++ b/vod/subtitle/dfxp_format.c
@@ -440,7 +440,7 @@ dfxp_parse(
 
 	if (xmlParseDocument(ctxt) != 0 ||
 		ctxt->myDoc == NULL ||
-		(!ctxt->wellFormed && !ctxt->recovery))
+		!ctxt->wellFormed)
 	{
 		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
 			"dfxp_parse: xml parsing failed");


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/libxml2/-/commit/712a31abe458eed75f0e2a442b35af58cf7091ca