### PR TITLE
fix broken/empty segments for sources with offset

### DIFF
--- a/vod/segmenter.c
+++ b/vod/segmenter.c
@@ -1949,6 +1949,9 @@ segmenter_get_segment_durations_accurate(
 
 	align_to_key_frames = conf->align_to_key_frames && main_track->media_info.media_type == MEDIA_TYPE_VIDEO;
 
+	segment_start = main_track->first_frame_time_offset;
+	accum_duration = main_track->first_frame_time_offset;
+
 	// bootstrap segments
 	if (conf->bootstrap_segments_count > 0)
 	{


### PR DESCRIPTION
This PR fixes an issue of generating broken segments (376 bytes) for a source with initial offset

When using source files with an initial offset, nginx-vod-module occasionally generates "broken" segments. For example, segment-2-v1-a1.ts (see bellow) may result in a file size of 376 bytes containing no actual packets. This causes players to hang as they attempt to retry downloading the empty segment indefinitely.

```
$ wget -qO- http://localhost:3030/hls/sample.mp4/index-v1-a1.m3u8
#EXTM3U
#EXT-X-TARGETDURATION:4
#EXT-X-ALLOW-CACHE:YES
#EXT-X-PLAYLIST-TYPE:VOD
#EXT-X-VERSION:3
#EXT-X-MEDIA-SEQUENCE:1
#EXTINF:3.920,
http://localhost:3030/hls/sample.mp4/segment-1-v1-a1.ts
#EXTINF:4.000,
http://localhost:3030/hls/sample.mp4/segment-2-v1-a1.ts
#EXTINF:4.000,
http://localhost:3030/hls/sample.mp4/segment-3-v1-a1.ts
#EXTINF:4.000,
http://localhost:3030/hls/sample.mp4/segment-4-v1-a1.ts
#EXTINF:4.080,
http://localhost:3030/hls/sample.mp4/segment-5-v1-a1.ts
#EXT-X-ENDLIST

$ wget -q http://localhost:3030/hls/sample.mp4/segment-{1,2,3,4,5}-v1-a1.ts
$ for t in *.ts; do ffprobe $t -of compact -hide_banner -show_entries format=filename,duration,bit_rate,size 2>/dev/null ; done
format|filename=segment-1-v1-a1.ts|duration=3.920000|size=135736|bit_rate=277012
format|filename=segment-2-v1-a1.ts|duration=N/A     |size=376   |bit_rate=N/A
format|filename=segment-3-v1-a1.ts|duration=4.080000|size=174840|bit_rate=342823
format|filename=segment-4-v1-a1.ts|duration=4.069333|size=198904|bit_rate=391030
format|filename=segment-5-v1-a1.ts|duration=4.080000|size=259064|bit_rate=507968
```

The described behavior is also mentioned here: https://github.com/kaltura/nginx-vod-module/issues/1072

### Environment
nginx: 1.29.3
nginx-vod-module: 1.33 / master (commit 26f0687)
Key nginx configuration: 
```
vod_bootstrap_segment_durations 2000;
vod_bootstrap_segment_durations 2000;
vod_segment_duration            4000;
```


### How to build a sample to reproduce
```
$ wget https://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4
$ ffmpeg -t 20 -i BigBuckBunny_320x180.mp4 -c:v libx264 -r 25 -output_ts_offset 0.2 -force_key_frames "0,3.9,7.9,11.9,15.9" -x264-params "scenecut=0" -y sample.mp4
```

### Key frames
```
$ ffprobe -show_entries frame=key_frame,pkt_pts_time -select_streams v -of compact sample.mp4 2>/dev/null | grep key_frame=1
frame|key_frame=1|pkt_pts_time=0.200000
frame|key_frame=1|pkt_pts_time=4.120000
frame|key_frame=1|pkt_pts_time=8.120000
frame|key_frame=1|pkt_pts_time=12.120000
frame|key_frame=1|pkt_pts_time=16.120000
```


### Root Cause
The issue stems from a synchronization mismatch between playlist generation and segment extraction:
**Playlist Generation**: To include a segment in the playlist, the module looks for at least one keyframe within a specific interval. Currently, this interval calculation ignores the initial offset. For segment-2-v1-a1.ts, the search interval is 2.0 - 4.0s. Given keyframes at 0, 3.92, 7.92..., the frame at 3.92 falls into the interval, so the segment is added to the playlist.
**Segment Delivery**: When the player actually requests the segment, the module takes the initial offset into account. If the offset is 0.2s, the keyframe's timestamp becomes 4.12s, which now falls outside the 2.0 - 4.0s window. As a result, the segment is generated empty.

### Proposed Solution
Modify the playlist generation logic to account for the initial offset of the first frame. This ensures that the playlist and the segment generator are perfectly synced, correctly excluding empty segments from the manifest.

### After the patch was applied

```
$ wget -qO- http://localhost:3030/hls/sample.mp4/index-v1-a1.m3u8
#EXTM3U
#EXT-X-TARGETDURATION:4
#EXT-X-ALLOW-CACHE:YES
#EXT-X-PLAYLIST-TYPE:VOD
#EXT-X-VERSION:3
#EXT-X-MEDIA-SEQUENCE:1
#EXTINF:3.920,
http://localhost:3030/hls/sample.mp4/segment-1-v1-a1.ts
#EXTINF:4.000,
http://localhost:3030/hls/sample.mp4/segment-3-v1-a1.ts
#EXTINF:4.000,
http://localhost:3030/hls/sample.mp4/segment-4-v1-a1.ts
#EXTINF:4.000,
http://localhost:3030/hls/sample.mp4/segment-5-v1-a1.ts
#EXTINF:4.080,
http://localhost:3030/hls/sample.mp4/segment-6-v1-a1.ts
#EXT-X-ENDLIST

$ wget -q http://localhost:3030/hls/sample.mp4/segment-{1,3,4,5,6}-v1-a1.ts
$ for t in *.ts; do ffprobe $t -of compact -hide_banner -show_entries format=filename,duration,bit_rate,size 2>/dev/null ; done
format|filename=segment-1-v1-a1.ts|duration=3.920000|size=135736|bit_rate=277012
format|filename=segment-3-v1-a1.ts|duration=4.080000|size=174840|bit_rate=342823
format|filename=segment-4-v1-a1.ts|duration=4.069333|size=198904|bit_rate=391030
format|filename=segment-5-v1-a1.ts|duration=4.080000|size=259064|bit_rate=507968
format|filename=segment-6-v1-a1.ts|duration=4.149333|size=141752|bit_rate=273300
```