### PR TITLE
fix: skip headers without named field offsets

### DIFF
--- a/ngx_child_http_request.c
+++ b/ngx_child_http_request.c
@@ -428,6 +428,10 @@ ngx_child_request_copy_headers(
 #if defined(nginx_version) && nginx_version >= 1023000
 	// zero all named header fields
 	for (hh = ngx_http_headers_in; hh->name.len; hh++) {
+		if (hh->offset == 0) {
+			continue;
+		}
+
 		ph = (ngx_table_elt_t **)((char *)dest + hh->offset);
 		*ph = NULL;
 	}
@@ -486,7 +490,7 @@ ngx_child_request_copy_headers(
 		// update the header pointer, if exists
 		hh = ngx_hash_find(&cmcf->headers_in_hash, ch->hash,
 			ch->lowcase_key, ch->key.len);
-		if (hh)
+		if (hh && hh->offset != 0)
 		{
 #if defined(nginx_version) && nginx_version >= 1023000
 			ph = (ngx_table_elt_t **)((char *)dest + hh->offset);


### PR DESCRIPTION
AI:
nginx may register known request headers with offset 0 when there is no corresponding `ngx_http_headers_in_t` pointer field to update, such as `Proxy-Connection` in newer nginx versions. Treating that value as a real struct offset writes through the start of `ngx_http_headers_in_t` and corrupts the headers list state.

Skip zero-offset `ngx_http_headers_in[]` entries when clearing named header pointers and when updating copied named header pointers. The header remains in the generic headers list, but no nonexistent named field is updated.

-----
Myself:
Actually I got inspired by the AI slop I've seen in https://github.com/kaltura/nginx-vod-module/pull/1607 and gived my AI a shot at this, all the changes done in #1607 were unnecessary, but there is really a problem in `nginx > 1.23.0` which can be fixed with minimal changes.